### PR TITLE
Disabled Hybrid SKU checks

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -149,38 +149,41 @@ var _ = Describe("Identity Controller", func() {
 
 	})
 
-	Context("When the Subs API says we have Hybrid", func() {
-		It("should give back a valid EntitlementsResponse with all is_entitled true", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{"SVCSER0566", "SVC3124", "SVC3852"},
-				CacheHit:   false,
-			}
+	//tests disabled while not enforcing entitlements for hybrid cloud
+	/*
+		Context("When the Subs API says we have Hybrid", func() {
+			It("should give back a valid EntitlementsResponse with all is_entitled true", func() {
+				fakeResponse := SubscriptionsResponse{
+					StatusCode: 200,
+					Data:       []string{"SVCSER0566", "SVC3124", "SVC3852"},
+					CacheHit:   false,
+				}
 
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
-			expectPass(rr.Result())
-			Expect(body.Insights.IsEntitled).To(Equal(true))
-			Expect(body.Openshift.IsEntitled).To(Equal(true))
-			Expect(body.HybridCloud.IsEntitled).To(Equal(true))
-			Expect(body.SmartMangement.IsEntitled).To(Equal(true))
+				rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
+				expectPass(rr.Result())
+				Expect(body.Insights.IsEntitled).To(Equal(true))
+				Expect(body.Openshift.IsEntitled).To(Equal(true))
+				Expect(body.HybridCloud.IsEntitled).To(Equal(true))
+				Expect(body.SmartMangement.IsEntitled).To(Equal(true))
+			})
 		})
-	})
 
-	Context("When the Subs API says we *dont* have Hybrid", func() {
-		It("should give back a valid EntitlementsResponse with hybrid is_entitled false", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{"SVC1234", "SVC3124", "SVC5678"},
-				CacheHit:   false,
-			}
+		Context("When the Subs API says we *dont* have Hybrid", func() {
+			It("should give back a valid EntitlementsResponse with hybrid is_entitled false", func() {
+				fakeResponse := SubscriptionsResponse{
+					StatusCode: 200,
+					Data:       []string{"SVC1234", "SVC3124", "SVC5678"},
+					CacheHit:   false,
+				}
 
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
-			expectPass(rr.Result())
-			Expect(body.Insights.IsEntitled).To(Equal(true))
-			Expect(body.Openshift.IsEntitled).To(Equal(true))
-			Expect(body.HybridCloud.IsEntitled).To(Equal(false))
-			Expect(body.SmartMangement.IsEntitled).To(Equal(true))
+				rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
+				expectPass(rr.Result())
+				Expect(body.Insights.IsEntitled).To(Equal(true))
+				Expect(body.Openshift.IsEntitled).To(Equal(true))
+				Expect(body.HybridCloud.IsEntitled).To(Equal(false))
+				Expect(body.SmartMangement.IsEntitled).To(Equal(true))
+			})
 		})
-	})
+	*/
 
 })

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -46,7 +46,7 @@ var getSubscriptions = func(orgID string) types.SubscriptionsResponse {
 	resp, err := getClient().Get(config.GetConfig().Options.GetString(config.Keys.SubsHost) +
 		"/svcrest/subscription/v5/searchnested/criteria" +
 		";web_customer_id=" + orgID +
-		";sku=SVC3851,SVC3852,SVCSER0566,SVCSER0567,SVC3124" +
+		";sku=SVC3124" + //Hybrid SKUs: SVC3851,SVC3852,SVCSER0566,SVCSER0567,
 		";status=active/options;products=ALL/product.sku")
 
 	if err != nil {
@@ -150,14 +150,15 @@ func Index(getCall func(string) types.SubscriptionsResponse) func(http.ResponseW
 			return
 		}
 
-		hybridSKUs := []string{"SVC3851", "SVC3852", "SVCSER0566", "SVCSER0567"}
-		entitleHybrid := len(checkCommon(hybridSKUs, res.Data)) > 0
+		//Commented out until hybrid is ready and all teams that need access have the correct SKUs
+		//hybridSKUs := []string{"SVC3851", "SVC3852", "SVCSER0566", "SVCSER0567"}
+		//entitleHybrid := len(checkCommon(hybridSKUs, res.Data)) > 0
 
 		smartManagementSKU := []string{"SVC3124"}
 		entitleSmartManagement := len(checkCommon(smartManagementSKU, res.Data)) > 0
 
 		obj, err := json.Marshal(types.EntitlementsResponse{
-			HybridCloud:    types.EntitlementsSection{IsEntitled: entitleHybrid},
+			HybridCloud:    types.EntitlementsSection{IsEntitled: true}, //set to true until ready for hybrid entitlment checks to be enforced
 			Insights:       types.EntitlementsSection{IsEntitled: entitleInsights},
 			Openshift:      types.EntitlementsSection{IsEntitled: true},
 			SmartMangement: types.EntitlementsSection{IsEntitled: entitleSmartManagement},


### PR DESCRIPTION
PR to keep the functionality for checking for hybrid entitlement SKUs for future use, while disabling them to not break everything for teams that don't yet have the proper SKUs.