### PR TITLE
Fix for OpenApi Specs not showing up in OpenShift

### DIFF
--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -22,7 +22,7 @@ func OpenAPISpec(r chi.Router) {
 	// options.AutomaticEnv()
 	keysPath := config.GetConfig().Options.GetString(config.Keys.CaPath)
 	fmt.Println(keysPath)
-	pathpath := config.GetConfig().Options.GetString(config.SpecFile.FilePath)
+	pathpath := config.GetConfig().Options.GetString(config.Keys.OpenSpecPath)
 	fmt.Println(pathpath)
 	specFile, err := ioutil.ReadFile(pathpath)
 	if err != nil {

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -1,7 +1,6 @@
 package apispec
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -12,19 +11,8 @@ import (
 
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
-	// currDir, err := os.Getwd()
-	// currDir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-	// fmt.Println(currDir)
-	// var specDir string
-	// var options = viper.New()
-	// options.SetDefault(specDir, "./apispec/api.spec.json")
-	// options.SetEnvPrefix("ENT")
-	// options.AutomaticEnv()
-	keysPath := config.GetConfig().Options.GetString(config.Keys.CaPath)
-	fmt.Println(keysPath)
-	pathpath := config.GetConfig().Options.GetString(config.Keys.OpenSpecPath)
-	fmt.Println(pathpath)
-	specFile, err := ioutil.ReadFile(pathpath)
+	specFilePath := config.GetConfig().Options.GetString(config.Keys.OpenAPISpecPath)
+	specFile, err := ioutil.ReadFile(specFilePath)
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("OpenApi Spec not available\n"))
@@ -33,7 +21,6 @@ func OpenAPISpec(r chi.Router) {
 		return
 	}
 
-	//byteArr, _ := ioutil.ReadAll(specFile)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(specFile)
 	})

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"path/filepath"
 
 	"github.com/go-chi/chi"
 )
@@ -12,7 +13,7 @@ import (
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
 	// currDir, err := os.Getwd()
-	specDir := "./apispec/api.spec.json"
+	specDir, _ := filepath.Abs("./apispec/api.spec.json")
 	fmt.Println(specDir)
 	specFile, err := ioutil.ReadFile(specDir)
 

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -20,6 +20,8 @@ func OpenAPISpec(r chi.Router) {
 	// options.SetDefault(specDir, "./apispec/api.spec.json")
 	// options.SetEnvPrefix("ENT")
 	// options.AutomaticEnv()
+	keysPath := config.GetConfig().Options.GetString(config.Keys.CaPath)
+	fmt.Println(keysPath)
 	pathpath := config.GetConfig().Options.GetString(config.OpenApiSpecFilePath)
 	fmt.Println(pathpath)
 	specFile, err := ioutil.ReadFile(pathpath)

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -22,7 +22,7 @@ func OpenAPISpec(r chi.Router) {
 	// options.AutomaticEnv()
 	keysPath := config.GetConfig().Options.GetString(config.Keys.CaPath)
 	fmt.Println(keysPath)
-	pathpath := config.GetConfig().Options.GetString(config.OpenAPISpecFilePath)
+	pathpath := config.GetConfig().Options.GetString(config.SpecFile.FilePath)
 	fmt.Println(pathpath)
 	specFile, err := ioutil.ReadFile(pathpath)
 	if err != nil {

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -1,7 +1,9 @@
 package apispec
 
 import (
+	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 
@@ -10,11 +12,15 @@ import (
 
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
-	specFile, err := os.Open("./apispec/api.spec.json")
+	currDir, err := os.Getwd()
+	specDir := string(currDir) + "/apispec/Aapi.spec.json"
+	fmt.Println(specDir)
+	specFile, err := os.Open(specDir)
 
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("OpenApi Spec not available\n"))
+			log.Panic(err)
 		})
 		return
 	}

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/RedHatInsights/entitlements-api-go/config"
 	"github.com/go-chi/chi"
-	"github.com/spf13/viper"
 )
 
 // OpenAPISpec responds back with the openapi spec
@@ -15,14 +15,14 @@ func OpenAPISpec(r chi.Router) {
 	// currDir, err := os.Getwd()
 	// currDir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
 	// fmt.Println(currDir)
-	var specDir string
-	var options = viper.New()
-	options.SetDefault(specDir, "./apispec/api.spec.json")
-	options.SetEnvPrefix("ENT")
-	options.AutomaticEnv()
-	specFile, err := ioutil.ReadFile(options.GetString(specDir))
-	fmt.Println(options.GetString(specDir))
-
+	// var specDir string
+	// var options = viper.New()
+	// options.SetDefault(specDir, "./apispec/api.spec.json")
+	// options.SetEnvPrefix("ENT")
+	// options.AutomaticEnv()
+	pathpath := config.GetConfig().Options.GetString(config.OpenApiSpecFilePath)
+	fmt.Println(pathpath)
+	specFile, err := ioutil.ReadFile(pathpath)
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("OpenApi Spec not available\n"))

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/go-chi/chi"
@@ -13,8 +14,10 @@ import (
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
 	// currDir, err := os.Getwd()
+	currDir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	fmt.Println(currDir)
 	specDir, _ := filepath.Abs("./apispec/api.spec.json")
-	fmt.Println(specDir)
+	// fmt.Println(specDir)
 	specFile, err := ioutil.ReadFile(specDir)
 
 	if err != nil {

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -22,7 +22,7 @@ func OpenAPISpec(r chi.Router) {
 	// options.AutomaticEnv()
 	keysPath := config.GetConfig().Options.GetString(config.Keys.CaPath)
 	fmt.Println(keysPath)
-	pathpath := config.GetConfig().Options.GetString(config.OpenApiSpecFilePath)
+	pathpath := config.GetConfig().Options.GetString(config.OpenAPISpecFilePath)
 	fmt.Println(pathpath)
 	specFile, err := ioutil.ReadFile(pathpath)
 	if err != nil {

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -5,17 +5,16 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/go-chi/chi"
 )
 
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
-	currDir, err := os.Getwd()
-	specDir := string(currDir) + "/apispec/api.spec.json"
+	// currDir, err := os.Getwd()
+	specDir := "./apispec/api.spec.json"
 	fmt.Println(specDir)
-	specFile, err := os.Open(specDir)
+	specFile, err := ioutil.ReadFile(specDir)
 
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -25,8 +24,8 @@ func OpenAPISpec(r chi.Router) {
 		return
 	}
 
-	byteArr, _ := ioutil.ReadAll(specFile)
+	//byteArr, _ := ioutil.ReadAll(specFile)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write(byteArr)
+		w.Write(specFile)
 	})
 }

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -5,20 +5,22 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 
 	"github.com/go-chi/chi"
+	"github.com/spf13/viper"
 )
 
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
 	// currDir, err := os.Getwd()
-	currDir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-	fmt.Println(currDir)
-	specDir, _ := filepath.Abs("./apispec/api.spec.json")
-	// fmt.Println(specDir)
-	specFile, err := ioutil.ReadFile(specDir)
+	// currDir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	// fmt.Println(currDir)
+	var specDir string
+	var options = viper.New()
+	options.SetDefault(specDir, "./apispec/api.spec.json")
+	options.AutomaticEnv()
+	specFile, err := ioutil.ReadFile(options.GetString(specDir))
+	fmt.Println(options.GetString(specDir))
 
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -18,6 +18,7 @@ func OpenAPISpec(r chi.Router) {
 	var specDir string
 	var options = viper.New()
 	options.SetDefault(specDir, "./apispec/api.spec.json")
+	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 	specFile, err := ioutil.ReadFile(options.GetString(specDir))
 	fmt.Println(options.GetString(specDir))

--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -13,7 +13,7 @@ import (
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
 	currDir, err := os.Getwd()
-	specDir := string(currDir) + "/apispec/Aapi.spec.json"
+	specDir := string(currDir) + "/apispec/api.spec.json"
 	fmt.Println(specDir)
 	specFile, err := os.Open(specDir)
 

--- a/config/main.go
+++ b/config/main.go
@@ -43,8 +43,8 @@ type EntitlementsOpenAPISpec struct {
 	FilePath string
 }
 
-var SpecFile = EntitlementsOpenAPISpec {
-	FilePath: "OPENAPI_SPEC_PATH"
+var SpecFile = EntitlementsOpenAPISpec{
+	FilePath: "OPENAPI_SPEC_PATH",
 }
 
 // OpenAPISpecFilePath is a blah blah blah

--- a/config/main.go
+++ b/config/main.go
@@ -21,35 +21,25 @@ type EntitlementsConfig struct {
 
 // EntitlementsConfigKeysType is the definition of the struct hat houses all the env variables key names
 type EntitlementsConfigKeysType struct {
-	Key          string
-	Cert         string
-	Port         string
-	CertsFromEnv string
-	SubsHost     string
-	CaPath       string
-	OpenSpecPath string
+	Key             string
+	Cert            string
+	Port            string
+	CertsFromEnv    string
+	SubsHost        string
+	CaPath          string
+	OpenAPISpecPath string
 }
 
 // Keys is a struct that houses all the env variables key names
 var Keys = EntitlementsConfigKeysType{
-	Key:          "KEY",
-	Cert:         "CERT",
-	Port:         "PORT",
-	CertsFromEnv: "CERTS_FROM_ENV",
-	SubsHost:     "SUBS_HOST",
-	CaPath:       "CA_PATH",
-	OpenSpecPath: "OPENAPI_SPEC_PATH",
+	Key:             "KEY",
+	Cert:            "CERT",
+	Port:            "PORT",
+	CertsFromEnv:    "CERTS_FROM_ENV",
+	SubsHost:        "SUBS_HOST",
+	CaPath:          "CA_PATH",
+	OpenAPISpecPath: "OPENAPI_SPEC_PATH",
 }
-
-// // EntitlementsOpenAPISpec ok...
-// type EntitlementsOpenAPISpec struct {
-// 	FilePath string
-// }
-
-// // SpecFile is something...
-// var SpecFile = EntitlementsOpenAPISpec{
-// 	FilePath: "OPENAPI_SPEC_PATH",
-// }
 
 func getRootCAs(localCertFile string) *x509.CertPool {
 	// force the CA cert
@@ -102,7 +92,7 @@ func initialize() {
 	options.SetDefault(Keys.Port, "3000")
 	options.SetDefault(Keys.SubsHost, "https://subscription.api.redhat.com")
 	options.SetDefault(Keys.CaPath, "./resources/ca.crt")
-	options.SetDefault(Keys.OpenSpecPath, "./apispec/api.spec.json")
+	options.SetDefault(Keys.OpenAPISpecPath, "./apispec/api.spec.json")
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 

--- a/config/main.go
+++ b/config/main.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"crypto/tls"
-	"github.com/spf13/viper"
 	"crypto/x509"
-	"io/ioutil"
 	"fmt"
- )
+	"io/ioutil"
+
+	"github.com/spf13/viper"
+)
 
 var config *EntitlementsConfig
 
@@ -20,23 +21,25 @@ type EntitlementsConfig struct {
 
 // EntitlementsConfigKeysType is the definition of the struct hat houses all the env variables key names
 type EntitlementsConfigKeysType struct {
-	Key string
-	Cert string
-	Port string
+	Key          string
+	Cert         string
+	Port         string
 	CertsFromEnv string
-	SubsHost string
-	CaPath string
+	SubsHost     string
+	CaPath       string
 }
 
 // Keys is a struct that houses all the env variables key names
-var Keys = EntitlementsConfigKeysType {
-	Key: "KEY",
-	Cert: "CERT",
-	Port: "PORT",
+var Keys = EntitlementsConfigKeysType{
+	Key:          "KEY",
+	Cert:         "CERT",
+	Port:         "PORT",
 	CertsFromEnv: "CERTS_FROM_ENV",
-	SubsHost: "SUBS_HOST",
-	CaPath: "CA_PATH",
+	SubsHost:     "SUBS_HOST",
+	CaPath:       "CA_PATH",
 }
+
+var OpenApiSpecFilePath string
 
 func getRootCAs(localCertFile string) *x509.CertPool {
 	// force the CA cert
@@ -61,8 +64,8 @@ func getRootCAs(localCertFile string) *x509.CertPool {
 	return rootCAs
 }
 
-func loadCerts(options *viper.Viper) (tls.Certificate, error){
-	if (options.GetBool("CERTS_FROM_ENV") == true) {
+func loadCerts(options *viper.Viper) (tls.Certificate, error) {
+	if options.GetBool("CERTS_FROM_ENV") == true {
 		return tls.X509KeyPair(
 			[]byte(options.GetString(Keys.Cert)),
 			[]byte(options.GetString(Keys.Key)),
@@ -89,6 +92,7 @@ func initialize() {
 	options.SetDefault(Keys.Port, "3000")
 	options.SetDefault(Keys.SubsHost, "https://subscription.api.redhat.com")
 	options.SetDefault(Keys.CaPath, "./resources/ca.crt")
+	options.SetDefault(OpenApiSpecFilePath, "./apispec/api.spec.json")
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 

--- a/config/main.go
+++ b/config/main.go
@@ -39,6 +39,14 @@ var Keys = EntitlementsConfigKeysType{
 	CaPath:       "CA_PATH",
 }
 
+type EntitlementsOpenAPISpec struct {
+	FilePath string
+}
+
+var SpecFile = EntitlementsOpenAPISpec {
+	FilePath: "OPENAPI_SPEC_PATH"
+}
+
 // OpenAPISpecFilePath is a blah blah blah
 var OpenAPISpecFilePath = "OPENAPI_SPEC_PATH"
 
@@ -93,7 +101,7 @@ func initialize() {
 	options.SetDefault(Keys.Port, "3000")
 	options.SetDefault(Keys.SubsHost, "https://subscription.api.redhat.com")
 	options.SetDefault(Keys.CaPath, "./resources/ca.crt")
-	options.SetDefault(OpenAPISpecFilePath, "./apispec/api.spec.json")
+	options.SetDefault(SpecFile.FilePath, "./apispec/api.spec.json")
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 

--- a/config/main.go
+++ b/config/main.go
@@ -27,6 +27,7 @@ type EntitlementsConfigKeysType struct {
 	CertsFromEnv string
 	SubsHost     string
 	CaPath       string
+	OpenSpecPath string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -37,18 +38,18 @@ var Keys = EntitlementsConfigKeysType{
 	CertsFromEnv: "CERTS_FROM_ENV",
 	SubsHost:     "SUBS_HOST",
 	CaPath:       "CA_PATH",
+	OpenSpecPath: "OPENAPI_SPEC_PATH",
 }
 
-type EntitlementsOpenAPISpec struct {
-	FilePath string
-}
+// // EntitlementsOpenAPISpec ok...
+// type EntitlementsOpenAPISpec struct {
+// 	FilePath string
+// }
 
-var SpecFile = EntitlementsOpenAPISpec{
-	FilePath: "OPENAPI_SPEC_PATH",
-}
-
-// OpenAPISpecFilePath is a blah blah blah
-var OpenAPISpecFilePath = "OPENAPI_SPEC_PATH"
+// // SpecFile is something...
+// var SpecFile = EntitlementsOpenAPISpec{
+// 	FilePath: "OPENAPI_SPEC_PATH",
+// }
 
 func getRootCAs(localCertFile string) *x509.CertPool {
 	// force the CA cert
@@ -101,7 +102,7 @@ func initialize() {
 	options.SetDefault(Keys.Port, "3000")
 	options.SetDefault(Keys.SubsHost, "https://subscription.api.redhat.com")
 	options.SetDefault(Keys.CaPath, "./resources/ca.crt")
-	options.SetDefault(SpecFile.FilePath, "./apispec/api.spec.json")
+	options.SetDefault(Keys.OpenSpecPath, "./apispec/api.spec.json")
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 

--- a/config/main.go
+++ b/config/main.go
@@ -39,7 +39,8 @@ var Keys = EntitlementsConfigKeysType{
 	CaPath:       "CA_PATH",
 }
 
-var OpenApiSpecFilePath string
+// OpenAPISpecFilePath is a blah blah blah
+var OpenAPISpecFilePath = "OPENAPI_SPEC_PATH"
 
 func getRootCAs(localCertFile string) *x509.CertPool {
 	// force the CA cert
@@ -92,7 +93,7 @@ func initialize() {
 	options.SetDefault(Keys.Port, "3000")
 	options.SetDefault(Keys.SubsHost, "https://subscription.api.redhat.com")
 	options.SetDefault(Keys.CaPath, "./resources/ca.crt")
-	options.SetDefault(OpenApiSpecFilePath, "./apispec/api.spec.json")
+	options.SetDefault(OpenAPISpecFilePath, "./apispec/api.spec.json")
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -24,8 +24,8 @@ func DoRoutes() chi.Router {
 
 	r.Route("/api/entitlements/v1", func(r chi.Router) {
 		r.Route("/", controllers.LubDub)
-		r.Get("/services", controllers.Index(nil))
 		r.Route("/openapi.json", apispec.OpenAPISpec)
+		r.Get("/services", controllers.Index(nil))
 	})
 
 	return r


### PR DESCRIPTION
fixes the openapi spec file not found error when deployed in OSD