### PR TITLE
temp: giving ansible entitlement with only valid account number

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -195,24 +195,24 @@ var _ = Describe("Identity Controller", func() {
 		})
 	})
 
-	Context("When the Subs API says we *dont* have Ansible", func() {
-		fakeResponse := SubscriptionsResponse{
-			StatusCode: 200,
-			Data:       []string{"SVC3852"},
-			CacheHit:   false,
-		}
+	// Context("When the Subs API says we *dont* have Ansible", func() {
+	// 	fakeResponse := SubscriptionsResponse{
+	// 		StatusCode: 200,
+	// 		Data:       []string{"SVC3852"},
+	// 		CacheHit:   false,
+	// 	}
 
-		It("should give back a valid EntitlementsResponse with ansible false", func() {
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
-			expectPass(rr.Result())
-			Expect(body.Insights.IsEntitled).To(Equal(true))
-			Expect(body.Openshift.IsEntitled).To(Equal(true))
-			Expect(body.HybridCloud.IsEntitled).To(Equal(true))
-			Expect(body.SmartManagement.IsEntitled).To(Equal(false))
-			Expect(body.Ansible.IsEntitled).To(Equal(false))
-			Expect(body.Migrations.IsEntitled).To(Equal(true))
-		})
-	})
+	// 	It("should give back a valid EntitlementsResponse with ansible false", func() {
+	// 		rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, fakeResponse))
+	// 		expectPass(rr.Result())
+	// 		Expect(body.Insights.IsEntitled).To(Equal(true))
+	// 		Expect(body.Openshift.IsEntitled).To(Equal(true))
+	// 		Expect(body.HybridCloud.IsEntitled).To(Equal(true))
+	// 		Expect(body.SmartManagement.IsEntitled).To(Equal(false))
+	// 		Expect(body.Ansible.IsEntitled).To(Equal(false))
+	// 		Expect(body.Migrations.IsEntitled).To(Equal(true))
+	// 	})
+	// })
 
 	Context("When the Subs API says we have Migrations", func() {
 		fakeResponse := SubscriptionsResponse{
@@ -228,7 +228,7 @@ var _ = Describe("Identity Controller", func() {
 			Expect(body.Openshift.IsEntitled).To(Equal(true))
 			Expect(body.HybridCloud.IsEntitled).To(Equal(true))
 			Expect(body.SmartManagement.IsEntitled).To(Equal(false))
-			Expect(body.Ansible.IsEntitled).To(Equal(false))
+			Expect(body.Ansible.IsEntitled).To(Equal(true))
 			Expect(body.Migrations.IsEntitled).To(Equal(true))
 		})
 	})

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -160,8 +160,8 @@ func Index(getCall func(string) types.SubscriptionsResponse) func(http.ResponseW
 		smartManagementSKU := []string{"SVC3124", "RH00068"}
 		entitleSmartManagement := len(checkCommon(smartManagementSKU, res.Data)) > 0
 
-		ansibleSKU := []string{"MCT3691", "MCT3692", "MCT3693", "MCT3694", "MCT3695", "MCT3696"}
-		entitleAnsible := validAccNum && len(checkCommon(ansibleSKU, res.Data)) > 0
+		// ansibleSKU := []string{"MCT3691", "MCT3692", "MCT3693", "MCT3694", "MCT3695", "MCT3696"}
+		// entitleAnsible := validAccNum && len(checkCommon(ansibleSKU, res.Data)) > 0
 
 		entitleMigrations := validAccNum
 
@@ -170,7 +170,7 @@ func Index(getCall func(string) types.SubscriptionsResponse) func(http.ResponseW
 			Insights:        types.EntitlementsSection{IsEntitled: entitleInsights},
 			Openshift:       types.EntitlementsSection{IsEntitled: true},
 			SmartManagement: types.EntitlementsSection{IsEntitled: entitleSmartManagement},
-			Ansible:         types.EntitlementsSection{IsEntitled: entitleAnsible},
+			Ansible:         types.EntitlementsSection{IsEntitled: validAccNum},
 			Migrations:      types.EntitlementsSection{IsEntitled: entitleMigrations},
 		})
 


### PR DESCRIPTION
Temporarily disabling SKU checks for Ansible and routing it through valid account number instead, until people gets unblocked on getting entitlements. 