### PR TITLE
WIP: one possible cleanup example

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package controllers
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	. "github.com/RedHatInsights/entitlements-api-go/controllers"
 	. "github.com/RedHatInsights/entitlements-api-go/types"
 	"github.com/RedHatInsights/platform-go-middlewares/identity"
 )
@@ -35,7 +34,9 @@ func testRequest(method string, path string, accnum string, orgid string, fakeCa
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	Index(fakeCaller, fakeBundleInfo)(rr, req)
+	GetSubscriptions = fakeCaller
+	BundleInfo = fakeBundleInfo
+	Index()(rr, req)
 
 	out, err := ioutil.ReadAll(rr.Result().Body)
 	Expect(err).To(BeNil(), "ioutil.ReadAll error was not nil")
@@ -62,18 +63,18 @@ func fakeGetSubscriptions(expectedOrgID string, expectedSkus string, response Su
 func fakeBundleInfo() func() []Bundle {
 	fakeBundle1 := Bundle{
 		Name: "TestBundle1",
-		Skus: []string{"SVC123","SVC456","MCT789"},
+		Skus: []string{"SVC123", "SVC456", "MCT789"},
 	}
 	fakeBundle2 := Bundle{
 		Name: "TestBundle2",
-		Skus: []string{"MCT1122","SVC3344"},
+		Skus: []string{"MCT1122", "SVC3344"},
 	}
 	fakeBundle3 := Bundle{
-		Name: "TestBundle3",
+		Name:           "TestBundle3",
 		UseValidAccNum: false,
 	}
 	fakeBundle4 := Bundle{
-		Name: "TestBundle4",
+		Name:           "TestBundle4",
 		UseValidAccNum: true,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/karlseguin/ccache v2.0.3+incompatible
 	github.com/karlseguin/expect v1.0.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/m1ome/zapper v0.0.0-20170328105535-8e169b0c5a1e // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,11 @@ github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+A
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/m1ome/zapper v0.0.0-20170328105535-8e169b0c5a1e h1:W6pZUS5NdOaO5MieYAFJR/KPvmn3TQRG+MrcGhmk4z0=
 github.com/m1ome/zapper v0.0.0-20170328105535-8e169b0c5a1e/go.mod h1:9fMT6bdveJEjgCweKVr6KSkwd06mIxrfwUms3lIHV3Y=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
@@ -197,6 +202,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/server/routes.go
+++ b/server/routes.go
@@ -24,7 +24,7 @@ func DoRoutes() chi.Router {
 	r.Route("/api/entitlements/v1", func(r chi.Router) {
 		r.With(identity.EnforceIdentity).Route("/", controllers.LubDub)
 		r.Route("/openapi.json", apispec.OpenAPISpec)
-		r.With(identity.EnforceIdentity).Get("/services", controllers.Index(nil, nil))
+		r.With(identity.EnforceIdentity).Get("/services", controllers.Index())
 	})
 
 	return r


### PR DESCRIPTION
See if this looks / reads better:

- removes the need for the 2 func arguments
- puts the tests in the same package as the units under test
- ran `go fmt` on the files (hence the whitespace changes)

There is still room for more cleanup if we figure out how to properly mock out the bundle info and the get subscriptions API call (would make things even cleaner).