### PR TITLE
Response for dependency errors

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"errors"
 
 	. "github.com/RedHatInsights/entitlements-api-go/types"
 	"github.com/RedHatInsights/platform-go-middlewares/identity"
@@ -83,7 +84,7 @@ var _ = Describe("Identity Controller", func() {
 		testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "deadbeef12", fakeGetSubscriptions("deadbeef12", "", fakeResponse))
 	})
 
-	Context("When the Subs API sends back an error", func() {
+	Context("When the Subs API sends back a non-200", func() {
 		It("should fail the response", func() {
 			rr, _, rawBody := testRequestWithDefaultOrgId("GET", "/", func(string, string) SubscriptionsResponse {
 				return SubscriptionsResponse{StatusCode: 503, Data: nil, CacheHit: false}
@@ -98,6 +99,24 @@ var _ = Describe("Identity Controller", func() {
 			Expect(jsonResponse.Error.Status).To(Equal(503))
 			Expect(jsonResponse.Error.Endpoint).To(Equal("https://subscription.api.redhat.com"))
 			Expect(jsonResponse.Error.Message).To(Equal("Got back a non 200 status code from Subscriptions Service"))
+		})
+	})
+
+	Context("When the Subs API sends back an error", func() {
+		It("should fail the response", func() {
+			rr, _, rawBody := testRequestWithDefaultOrgId("GET", "/", func(string, string) SubscriptionsResponse {
+				return SubscriptionsResponse{StatusCode: 503, Data: nil, CacheHit: false, Error: errors.New("Sub Failure")}
+			})
+
+			var jsonResponse DependencyErrorResponse
+			json.Unmarshal([]byte(rawBody), &jsonResponse)
+
+			Expect(rr.Result().StatusCode).To(Equal(500))
+			Expect(jsonResponse.Error.DependencyFailure).To(Equal(true))
+			Expect(jsonResponse.Error.Service).To(Equal("Subscriptions Service"))
+			Expect(jsonResponse.Error.Status).To(Equal(503))
+			Expect(jsonResponse.Error.Endpoint).To(Equal("https://subscription.api.redhat.com"))
+			Expect(jsonResponse.Error.Message).To(Equal("Unexpected error while talking to Subs Service"))
 		})
 	})
 

--- a/types/main.go
+++ b/types/main.go
@@ -37,15 +37,15 @@ type Bundle struct {
 // DependencyErrorDetails is a struct that is used to marshal failure details
 // from failed requests to the subscriptions service
 type DependencyErrorDetails struct {
-    DependencyFailure bool   `json:"dependency_failure"`
-    Service           string `json:"service"`
-    Status            int    `json:"status"`
-    Endpoint          string `json:"endpoint"`
-    Message           string `json:"message"`
+	DependencyFailure bool   `json:"dependency_failure"`
+	Service           string `json:"service"`
+	Status            int    `json:"status"`
+	Endpoint          string `json:"endpoint"`
+	Message           string `json:"message"`
 }
 
 // DependencyErrorResponse is a struct that is used to marshal an error response
 // based on details from a failed request to the subscriptions service
 type DependencyErrorResponse struct {
-    Error DependencyErrorDetails `json:"error"`
+	Error DependencyErrorDetails `json:"error"`
 }

--- a/types/main.go
+++ b/types/main.go
@@ -33,3 +33,15 @@ type Bundle struct {
 	UseValidAccNum bool     `yaml:"use_valid_acc_num"`
 	Skus           []string `yaml:"skus"`
 }
+
+type DependencyErrorDetails struct {
+	DependencyFailure bool   `json:"dependency_failure"`
+	Service 					string `json:"service"`
+	Status 						int    `json:"status"`
+	Endpoint					string `json:"endpoint"`
+	Message 					string `json:"message"`
+}
+
+type DependencyErrorResponse struct {
+	Error DependencyErrorDetails `json:error`
+}

--- a/types/main.go
+++ b/types/main.go
@@ -34,14 +34,18 @@ type Bundle struct {
 	Skus           []string `yaml:"skus"`
 }
 
+// DependencyErrorDetails is a struct that is used to marshal failure details
+// from failed requests to the subscriptions service
 type DependencyErrorDetails struct {
-	DependencyFailure bool   `json:"dependency_failure"`
-	Service 					string `json:"service"`
-	Status 						int    `json:"status"`
-	Endpoint					string `json:"endpoint"`
-	Message 					string `json:"message"`
+    DependencyFailure bool   `json:"dependency_failure"`
+    Service           string `json:"service"`
+    Status            int    `json:"status"`
+    Endpoint          string `json:"endpoint"`
+    Message           string `json:"message"`
 }
 
+// DependencyErrorResponse is a struct that is used to marshal an error response
+// based on details from a failed request to the subscriptions service
 type DependencyErrorResponse struct {
-	Error DependencyErrorDetails `json:error`
+    Error DependencyErrorDetails `json:"error"`
 }


### PR DESCRIPTION
The platform gateway will soon be expecting a specifically formatted response
for dependency errors. This will help more easily triage where entitlement
request failures are originating from, so that response time for remediation
is reduced.

The gateway will implement metrics and alerting based on these responses.

This new contract should be returned by the entitlements service when:
- a non-200 response is received from subscriptions
- an error is received from subscriptions

Both of these scenarios should provide context on the failure, through the
following:

```
{
  "error": {
    "dependency_failure": true,
    "service": <DEPENDENT_SERVICE_THAT_FAILED>,
    "status": <STATUS_FROM_DEPENDENT_SERVICE>,
    "endpoint": <DEPENDENT_ENDPOINT_THAT_FAILED>,
    "message": <ERROR_MESSAGE_FROM_YOUR_SERVICE>
  }
}
```

This PR adds structs for `DependencyErrorDetails` and `DependencyErrorResponse`,
which are used to supply information during a non-200 or failure from the
subscriptions service.

To reuse some of the shared logic between the two types of dependency failures, this
also abstracts a function to set the failure based on the response and error message.