### PR TITLE
Changing the eval SKU for smart management

### DIFF
--- a/bundles/bundles.yml
+++ b/bundles/bundles.yml
@@ -25,4 +25,4 @@
 - name: smart_management
   skus:
     - SVC3124
-    - RH00068
+    - RH00066


### PR DESCRIPTION
Apparently the original request to use RH00068 was incorrect.
We should use RH00066.