### PR TITLE
Update the name of the log level attribute for CloudWatch

### DIFF
--- a/logger/main.go
+++ b/logger/main.go
@@ -45,7 +45,7 @@ func InitLogger() *logrus.Logger {
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyTime:  "ts",
 				logrus.FieldKeyFunc:  "caller",
-				logrus.FieldKeyLevel: "level",
+				logrus.FieldKeyLevel: "logLevel",
 				logrus.FieldKeyMsg:   "msg",
 			},
 		}


### PR DESCRIPTION
All of our applications' indices in Kibana share an attribute mapping. This means
that if an application has a field named `level` for instance, Kibana will infer
the field type from the firsts entry. Any further log requests with that field will
be expected to adhere to that format.

In production, the advisor app has the attribute `level` in their logs, which is
of type `long` in Kibana. This means that when entitlements logs are sent from
CloudWatch to Kibana, they fail to be rendered because in entitlements, `level`
is a string.

This seems like more of a systemic problem with having our log mappings shared
across apps, but in order to resolve this for entitlements, we can just update
the `level` key to `logLevel`, which is not currently used in our Kibana mappings.