### PR TITLE
Add missing `cost_management` entitlement SKUs

### DIFF
--- a/bundles/bundles.yml
+++ b/bundles/bundles.yml
@@ -53,6 +53,8 @@
     - MW00332
     - MW00421
     - MW00422
+    - MCT2862
+    - MCT2863
 
 - name: insights
   use_valid_acc_num: true


### PR DESCRIPTION
In order to support current admin accounts which should have access to the
`cost_management` entitlement, two additional SKUs should be added.

cc: @chambridge @adberglund - I wasn't able to add you as reviewers directly 