### PR TITLE
Support trial skus and payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,6 @@ For an example see `cat ./scripts/xrhid_helper.sh`
 * To run the unit tests, execute the following commands from the terminal:
     `cd controllers`
     `go test`
+* To include benchmarks:
+    `cd controllers`
+    `go test -bench=.`

--- a/bundles/bundles.example.yml
+++ b/bundles/bundles.example.yml
@@ -1,277 +1,540 @@
 - name: ansible
   skus:
-    - MCT3691: {is_trial: false}
-    - MCT3691RN: {is_trial: false}
-    - MCT3691F3: {is_trial: false}
-    - MCT3691F3RN: {is_trial: false}
-    - MCT3691S: {is_trial: false}
-    - MCT3692: {is_trial: false}
-    - MCT3692RN: {is_trial: false}
-    - MCT3692F3: {is_trial: false}
-    - MCT3692F3RN: {is_trial: false}
-    - MCT3692S: {is_trial: false}
-    - MCT3693: {is_trial: false}
-    - MCT3693RN: {is_trial: false}
-    - MCT3693F3: {is_trial: false}
-    - MCT3693F3RN: {is_trial: false}
-    - MCT3693S: {is_trial: false}
-    - MCT3694: {is_trial: false}
-    - MCT3694RN: {is_trial: false}
-    - MCT3694F3: {is_trial: false}
-    - MCT3694F3RN: {is_trial: false}
-    - MCT3694S: {is_trial: false}
-    - MCT3695: {is_trial: false}
-    - MCT3695RN: {is_trial: false}
-    - MCT3695F3: {is_trial: false}
-    - MCT3695F3RN: {is_trial: false}
-    - MCT3695S: {is_trial: false}
-    - MCT3696: {is_trial: false}
-    - MCT3696RN: {is_trial: false}
-    - MCT3696F3: {is_trial: false}
-    - MCT3696F3RN: {is_trial: false}
-    - MCT3696S: {is_trial: false}
-    - MCT3733: {is_trial: false}
-    - MCT3733RN: {is_trial: false}
-    - MCT3733F3: {is_trial: false}
-    - MCT3733F3RN: {is_trial: false}
-    - MCT3733S: {is_trial: false}
-    - SER0496: {is_trial: false}
-    - SER0496RN: {is_trial: false}
-    - SER0496F3: {is_trial: false}
-    - SER0496F3RN: {is_trial: false}
-    - SER0496S: {is_trial: false}
-    - SER0497: {is_trial: false}
-    - SER0497RN: {is_trial: false}
-    - SER0497F3: {is_trial: false}
-    - SER0497F3RN: {is_trial: false}
-    - SER0497S: {is_trial: false}
-    - SER0569: {is_trial: false}
-    - SER0569RN: {is_trial: false}
-    - SER0569F3: {is_trial: false}
-    - SER0569F3RN: {is_trial: false}
-    - SER0569S: {is_trial: false}
+    MCT3691:
+        is_trial: false
+    MCT3691RN:
+        is_trial: false
+    MCT3691F3:
+        is_trial: false
+    MCT3691F3RN:
+        is_trial: false
+    MCT3691S:
+        is_trial: false
+    MCT3692:
+        is_trial: false
+    MCT3692RN:
+        is_trial: false
+    MCT3692F3:
+        is_trial: false
+    MCT3692F3RN:
+        is_trial: false
+    MCT3692S:
+        is_trial: false
+    MCT3693:
+        is_trial: false
+    MCT3693RN:
+        is_trial: false
+    MCT3693F3:
+        is_trial: false
+    MCT3693F3RN:
+        is_trial: false
+    MCT3693S:
+        is_trial: false
+    MCT3694:
+        is_trial: false
+    MCT3694RN:
+        is_trial: false
+    MCT3694F3:
+        is_trial: false
+    MCT3694F3RN:
+        is_trial: false
+    MCT3694S:
+        is_trial: false
+    MCT3695:
+        is_trial: false
+    MCT3695RN:
+        is_trial: false
+    MCT3695F3:
+        is_trial: false
+    MCT3695F3RN:
+        is_trial: false
+    MCT3695S:
+        is_trial: false
+    MCT3696:
+        is_trial: false
+    MCT3696RN:
+        is_trial: false
+    MCT3696F3:
+        is_trial: false
+    MCT3696F3RN:
+        is_trial: false
+    MCT3696S:
+        is_trial: false
+    MCT3733:
+        is_trial: false
+    MCT3733RN:
+        is_trial: false
+    MCT3733F3:
+        is_trial: false
+    MCT3733F3RN:
+        is_trial: false
+    MCT3733S:
+        is_trial: false
+    SER0496:
+        is_trial: false
+    SER0496RN:
+        is_trial: false
+    SER0496F3:
+        is_trial: false
+    SER0496F3RN:
+        is_trial: false
+    SER0496S:
+        is_trial: false
+    SER0497:
+        is_trial: false
+    SER0497RN:
+        is_trial: false
+    SER0497F3:
+        is_trial: false
+    SER0497F3RN:
+        is_trial: false
+    SER0497S:
+        is_trial: false
+    SER0569:
+        is_trial: false
+    SER0569RN:
+        is_trial: false
+    SER0569F3:
+        is_trial: false
+    SER0569F3RN:
+        is_trial: false
+    SER0569S:
+        is_trial: false
 
 - name: cost_management
   skus:
-    - MW00454: {is_trial: false}
-    - MW00455: {is_trial: false}
-    - MW00456: {is_trial: false}
-    - MW00457: {is_trial: false}
-    - MW00458: {is_trial: false}
-    - MW00459: {is_trial: false}
-    - MW00448: {is_trial: false}
-    - MW00449: {is_trial: false}
-    - MW00450: {is_trial: false}
-    - MW00451: {is_trial: false}
-    - MW00452: {is_trial: false}
-    - MW00453: {is_trial: false}
-    - MW00373: {is_trial: false}
-    - MW00374: {is_trial: false}
-    - MW00375: {is_trial: false}
-    - MW00376: {is_trial: false}
-    - MW00377: {is_trial: false}
-    - MW00378: {is_trial: false}
-    - MW00361: {is_trial: false}
-    - MW00362: {is_trial: false}
-    - MW00363: {is_trial: false}
-    - MW00364: {is_trial: false}
-    - MW00365: {is_trial: false}
-    - MW00366: {is_trial: false}
-    - MCT2735: {is_trial: false}
-    - MCT2736: {is_trial: false}
-    - MCT3489: {is_trial: false}
-    - MCT3490: {is_trial: false}
-    - MCT3753: {is_trial: false}
-    - MCT3754: {is_trial: false}
-    - MCT3759: {is_trial: false}
-    - MCT3760: {is_trial: false}
-    - MW00329: {is_trial: false}
-    - MW00330: {is_trial: false}
-    - MW00331: {is_trial: false}
-    - MW00332: {is_trial: false}
-    - MW00421: {is_trial: false}
-    - MW00422: {is_trial: false}
-    - MCT2862: {is_trial: false}
-    - MCT2863: {is_trial: false}
+    MW00454:
+        is_trial: false
+    MW00455:
+        is_trial: false
+    MW00456:
+        is_trial: false
+    MW00457:
+        is_trial: false
+    MW00458:
+        is_trial: false
+    MW00459:
+        is_trial: false
+    MW00448:
+        is_trial: false
+    MW00449:
+        is_trial: false
+    MW00450:
+        is_trial: false
+    MW00451:
+        is_trial: false
+    MW00452:
+        is_trial: false
+    MW00453:
+        is_trial: false
+    MW00373:
+        is_trial: false
+    MW00374:
+        is_trial: false
+    MW00375:
+        is_trial: false
+    MW00376:
+        is_trial: false
+    MW00377:
+        is_trial: false
+    MW00378:
+        is_trial: false
+    MW00361:
+        is_trial: false
+    MW00362:
+        is_trial: false
+    MW00363:
+        is_trial: false
+    MW00364:
+        is_trial: false
+    MW00365:
+        is_trial: false
+    MW00366:
+        is_trial: false
+    MCT2735:
+        is_trial: false
+    MCT2736:
+        is_trial: false
+    MCT3489:
+        is_trial: false
+    MCT3490:
+        is_trial: false
+    MCT3753:
+        is_trial: false
+    MCT3754:
+        is_trial: false
+    MCT3759:
+        is_trial: false
+    MCT3760:
+        is_trial: false
+    MW00329:
+        is_trial: false
+    MW00330:
+        is_trial: false
+    MW00331:
+        is_trial: false
+    MW00332:
+        is_trial: false
+    MW00421:
+        is_trial: false
+    MW00422:
+        is_trial: false
+    MCT2862:
+        is_trial: false
+    MCT2863:
+        is_trial: false
 
 - name: insights
   use_valid_acc_num: true
 
 - name: migrations
   skus:
-    - SER0584: {is_trial: false}
-    - CL216: {is_trial: false}
-    - CL216OS: {is_trial: false}
-    - CL216VT: {is_trial: false}
-    - CL218: {is_trial: false}
-    - CL218IGE: {is_trial: false}
-    - CL218OS: {is_trial: false}
-    - CL218PT: {is_trial: false}
-    - CL218VT: {is_trial: false}
-    - CL220: {is_trial: false}
-    - CL220IGE: {is_trial: false}
-    - CL220IGE-R1: {is_trial: false}
-    - CL220IGE-R2: {is_trial: false}
-    - CL220IGE-R3: {is_trial: false}
-    - CL220OS: {is_trial: false}
-    - CL220VC: {is_trial: false}
-    - ESA0017: {is_trial: false}
-    - ESA0039: {is_trial: false}
-    - MCT2358: {is_trial: false}
-    - MCT2358F3: {is_trial: false}
-    - MCT2358F3RN: {is_trial: false}
-    - MCT2358RN: {is_trial: false}
-    - MCT2360: {is_trial: false}
-    - MCT2360F3: {is_trial: false}
-    - MCT2360F3RN: {is_trial: false}
-    - MCT2360RN: {is_trial: false}
-    - MCT2834: {is_trial: false}
-    - MCT2838: {is_trial: false}
-    - MCT2838F3: {is_trial: false}
-    - MCT2838F3RN: {is_trial: false}
-    - MCT2838RN: {is_trial: false}
-    - MCT2838S: {is_trial: false}
-    - MCT2839: {is_trial: false}
-    - MCT2839F3: {is_trial: false}
-    - MCT2839F3RN: {is_trial: false}
-    - MCT2839RN: {is_trial: false}
-    - MCT2840: {is_trial: false}
-    - MCT2840F3: {is_trial: false}
-    - MCT2840F3RN: {is_trial: false}
-    - MCT2840RN: {is_trial: false}
-    - MCT2841: {is_trial: false}
-    - MCT2841F3: {is_trial: false}
-    - MCT2841F3RN: {is_trial: false}
-    - MCT2841RN: {is_trial: false}
-    - MCT2841S: {is_trial: false}
-    - MCT2842: {is_trial: false}
-    - MCT2842F3: {is_trial: false}
-    - MCT2842F3RN: {is_trial: false}
-    - MCT2842RN: {is_trial: false}
-    - MCT2843: {is_trial: false}
-    - MCT2843F3: {is_trial: false}
-    - MCT2843F3RN: {is_trial: false}
-    - MCT2843RN: {is_trial: false}
-    - MCT2856: {is_trial: false}
-    - MCT2856F3: {is_trial: false}
-    - MCT2856F3RN: {is_trial: false}
-    - MCT2856RN: {is_trial: false}
-    - MCT2856S: {is_trial: false}
-    - MCT2955: {is_trial: false}
-    - MCT3116: {is_trial: false}
-    - MCT3158: {is_trial: false}
-    - MCT3159: {is_trial: false}
-    - MCT3867: {is_trial: false}
-    - MCT3868: {is_trial: false}
-    - PT208: {is_trial: false}
-    - RH00541: {is_trial: false}
-    - RH00541F3: {is_trial: false}
-    - RH00541F3RN: {is_trial: false}
-    - RH00541RN: {is_trial: false}
-    - RH00541S: {is_trial: false}
-    - RH00542: {is_trial: false}
-    - RH00542F3: {is_trial: false}
-    - RH00542F3RN: {is_trial: false}
-    - RH00542RN: {is_trial: false}
-    - RH00542S: {is_trial: false}
-    - RH00543: {is_trial: false}
-    - RH00543F3: {is_trial: false}
-    - RH00543F3RN: {is_trial: false}
-    - RH00543RN: {is_trial: false}
-    - RH00543S: {is_trial: false}
-    - RH00544: {is_trial: false}
-    - RH00544F3: {is_trial: false}
-    - RH00544F3RN: {is_trial: false}
-    - RH00544RN: {is_trial: false}
-    - RH00544S: {is_trial: false}
-    - RV00062: {is_trial: false}
-    - RV00062F3: {is_trial: false}
-    - RV00062F3RN: {is_trial: false}
-    - RV00062RN: {is_trial: false}
-    - RV00062S: {is_trial: false}
-    - RV00063: {is_trial: false}
-    - RV00063F3: {is_trial: false}
-    - RV00063F3RN: {is_trial: false}
-    - RV00063RN: {is_trial: false}
-    - RV00063S: {is_trial: false}
-    - RV00064: {is_trial: false}
-    - RV00064F3: {is_trial: false}
-    - RV00064F3RN: {is_trial: false}
-    - RV00064RN: {is_trial: false}
-    - RV00064S: {is_trial: false}
-    - SER0407: {is_trial: false}
-    - SER0408: {is_trial: false}
-    - SER0412: {is_trial: false}
-    - SER0430: {is_trial: false}
-    - SER0431: {is_trial: false}
-    - SER0432: {is_trial: false}
-    - SER0433: {is_trial: false}
-    - SER0442: {is_trial: false}
-    - SER0583: {is_trial: false}
-    - SER0584: {is_trial: false}
-    - SVC1356: {is_trial: false}
-    - SVC1358: {is_trial: false}
-    - SVC1396: {is_trial: false}
-    - SVC1885: {is_trial: false}
-    - SVC1936: {is_trial: false}
-    - SVC1937: {is_trial: false}
-    - SVC1938: {is_trial: false}
-    - SVC1939: {is_trial: false}
-    - SVC1940: {is_trial: false}
-    - SVC1941: {is_trial: false}
-    - SVC1942: {is_trial: false}
-    - SVC1943: {is_trial: false}
-    - SVC1944: {is_trial: false}
-    - SVC1945: {is_trial: false}
-    - SVC1958: {is_trial: false}
-    - SVC1974: {is_trial: false}
-    - SVC2058: {is_trial: false}
-    - SVC2059: {is_trial: false}
-    - SVC2450: {is_trial: false}
-    - SVC2492: {is_trial: false}
-    - SVC2493: {is_trial: false}
-    - SVC3867: {is_trial: false}
-    - SVC3868: {is_trial: false}
-    - SVCCL220VC: {is_trial: false}
-    - SVCESA0017: {is_trial: false}
-    - SVCESA0039: {is_trial: false}
-    - SVCRH00541: {is_trial: false}
-    - SVCRH00542: {is_trial: false}
-    - SVCRH00543: {is_trial: false}
-    - SVCRH00544: {is_trial: false}
-    - SVCRV00062: {is_trial: false}
-    - SVCRV00063: {is_trial: false}
-    - SVCRV00064: {is_trial: false}
-    - SVCSER0583: {is_trial: false}
-    - SVCSER0584: {is_trial: false}
-    - SYS1356: {is_trial: false}
-    - SYS1358: {is_trial: false}
-    - SYS1396: {is_trial: false}
-    - SYS1885: {is_trial: false}
-    - SYS1936: {is_trial: false}
-    - SYS1937: {is_trial: false}
-    - SYS1938: {is_trial: false}
-    - SYS1939: {is_trial: false}
-    - SYS1940: {is_trial: false}
-    - SYS1941: {is_trial: false}
-    - SYS1942: {is_trial: false}
-    - SYS1943: {is_trial: false}
-    - SYS1944: {is_trial: false}
-    - SYS1945: {is_trial: false}
-    - SYS1958: {is_trial: false}
-    - SYS1974: {is_trial: false}
-    - SYS2058: {is_trial: false}
-    - SYS2059: {is_trial: false}
-    - SYS2450: {is_trial: false}
-    - SYS2492: {is_trial: false}
-    - SYS2493: {is_trial: false}
-    - TRK216: {is_trial: false}
-    - TRK218: {is_trial: false}
-    - TRK218IG: {is_trial: false}
-    - TRK220: {is_trial: false}
-    - TRK220IG: {is_trial: false}
-    - TRK220IG-R4: {is_trial: false}
-    - TRK220IG-R5: {is_trial: false}
+    SER0584:
+        is_trial: false
+    CL216:
+        is_trial: false
+    CL216OS:
+        is_trial: false
+    CL216VT:
+        is_trial: false
+    CL218:
+        is_trial: false
+    CL218IGE:
+        is_trial: false
+    CL218OS:
+        is_trial: false
+    CL218PT:
+        is_trial: false
+    CL218VT:
+        is_trial: false
+    CL220:
+        is_trial: false
+    CL220IGE:
+        is_trial: false
+    CL220IGE-R1:
+        is_trial: false
+    CL220IGE-R2:
+        is_trial: false
+    CL220IGE-R3:
+        is_trial: false
+    CL220OS:
+        is_trial: false
+    CL220VC:
+        is_trial: false
+    ESA0017:
+        is_trial: false
+    ESA0039:
+        is_trial: false
+    MCT2358:
+        is_trial: false
+    MCT2358F3:
+        is_trial: false
+    MCT2358F3RN:
+        is_trial: false
+    MCT2358RN:
+        is_trial: false
+    MCT2360:
+        is_trial: false
+    MCT2360F3:
+        is_trial: false
+    MCT2360F3RN:
+        is_trial: false
+    MCT2360RN:
+        is_trial: false
+    MCT2834:
+        is_trial: false
+    MCT2838:
+        is_trial: false
+    MCT2838F3:
+        is_trial: false
+    MCT2838F3RN:
+        is_trial: false
+    MCT2838RN:
+        is_trial: false
+    MCT2838S:
+        is_trial: false
+    MCT2839:
+        is_trial: false
+    MCT2839F3:
+        is_trial: false
+    MCT2839F3RN:
+        is_trial: false
+    MCT2839RN:
+        is_trial: false
+    MCT2840:
+        is_trial: false
+    MCT2840F3:
+        is_trial: false
+    MCT2840F3RN:
+        is_trial: false
+    MCT2840RN:
+        is_trial: false
+    MCT2841:
+        is_trial: false
+    MCT2841F3:
+        is_trial: false
+    MCT2841F3RN:
+        is_trial: false
+    MCT2841RN:
+        is_trial: false
+    MCT2841S:
+        is_trial: false
+    MCT2842:
+        is_trial: false
+    MCT2842F3:
+        is_trial: false
+    MCT2842F3RN:
+        is_trial: false
+    MCT2842RN:
+        is_trial: false
+    MCT2843:
+        is_trial: false
+    MCT2843F3:
+        is_trial: false
+    MCT2843F3RN:
+        is_trial: false
+    MCT2843RN:
+        is_trial: false
+    MCT2856:
+        is_trial: false
+    MCT2856F3:
+        is_trial: false
+    MCT2856F3RN:
+        is_trial: false
+    MCT2856RN:
+        is_trial: false
+    MCT2856S:
+        is_trial: false
+    MCT2955:
+        is_trial: false
+    MCT3116:
+        is_trial: false
+    MCT3158:
+        is_trial: false
+    MCT3159:
+        is_trial: false
+    MCT3867:
+        is_trial: false
+    MCT3868:
+        is_trial: false
+    PT208:
+        is_trial: false
+    RH00541:
+        is_trial: false
+    RH00541F3:
+        is_trial: false
+    RH00541F3RN:
+        is_trial: false
+    RH00541RN:
+        is_trial: false
+    RH00541S:
+        is_trial: false
+    RH00542:
+        is_trial: false
+    RH00542F3:
+        is_trial: false
+    RH00542F3RN:
+        is_trial: false
+    RH00542RN:
+        is_trial: false
+    RH00542S:
+        is_trial: false
+    RH00543:
+        is_trial: false
+    RH00543F3:
+        is_trial: false
+    RH00543F3RN:
+        is_trial: false
+    RH00543RN:
+        is_trial: false
+    RH00543S:
+        is_trial: false
+    RH00544:
+        is_trial: false
+    RH00544F3:
+        is_trial: false
+    RH00544F3RN:
+        is_trial: false
+    RH00544RN:
+        is_trial: false
+    RH00544S:
+        is_trial: false
+    RV00062:
+        is_trial: false
+    RV00062F3:
+        is_trial: false
+    RV00062F3RN:
+        is_trial: false
+    RV00062RN:
+        is_trial: false
+    RV00062S:
+        is_trial: false
+    RV00063:
+        is_trial: false
+    RV00063F3:
+        is_trial: false
+    RV00063F3RN:
+        is_trial: false
+    RV00063RN:
+        is_trial: false
+    RV00063S:
+        is_trial: false
+    RV00064:
+        is_trial: false
+    RV00064F3:
+        is_trial: false
+    RV00064F3RN:
+        is_trial: false
+    RV00064RN:
+        is_trial: false
+    RV00064S:
+        is_trial: false
+    SER0407:
+        is_trial: false
+    SER0408:
+        is_trial: false
+    SER0412:
+        is_trial: false
+    SER0430:
+        is_trial: false
+    SER0431:
+        is_trial: false
+    SER0432:
+        is_trial: false
+    SER0433:
+        is_trial: false
+    SER0442:
+        is_trial: false
+    SER0583:
+        is_trial: false
+    SER0584:
+        is_trial: false
+    SVC1356:
+        is_trial: false
+    SVC1358:
+        is_trial: false
+    SVC1396:
+        is_trial: false
+    SVC1885:
+        is_trial: false
+    SVC1936:
+        is_trial: false
+    SVC1937:
+        is_trial: false
+    SVC1938:
+        is_trial: false
+    SVC1939:
+        is_trial: false
+    SVC1940:
+        is_trial: false
+    SVC1941:
+        is_trial: false
+    SVC1942:
+        is_trial: false
+    SVC1943:
+        is_trial: false
+    SVC1944:
+        is_trial: false
+    SVC1945:
+        is_trial: false
+    SVC1958:
+        is_trial: false
+    SVC1974:
+        is_trial: false
+    SVC2058:
+        is_trial: false
+    SVC2059:
+        is_trial: false
+    SVC2450:
+        is_trial: false
+    SVC2492:
+        is_trial: false
+    SVC2493:
+        is_trial: false
+    SVC3867:
+        is_trial: false
+    SVC3868:
+        is_trial: false
+    SVCCL220VC:
+        is_trial: false
+    SVCESA0017:
+        is_trial: false
+    SVCESA0039:
+        is_trial: false
+    SVCRH00541:
+        is_trial: false
+    SVCRH00542:
+        is_trial: false
+    SVCRH00543:
+        is_trial: false
+    SVCRH00544:
+        is_trial: false
+    SVCRV00062:
+        is_trial: false
+    SVCRV00063:
+        is_trial: false
+    SVCRV00064:
+        is_trial: false
+    SVCSER0583:
+        is_trial: false
+    SVCSER0584:
+        is_trial: false
+    SYS1356:
+        is_trial: false
+    SYS1358:
+        is_trial: false
+    SYS1396:
+        is_trial: false
+    SYS1885:
+        is_trial: false
+    SYS1936:
+        is_trial: false
+    SYS1937:
+        is_trial: false
+    SYS1938:
+        is_trial: false
+    SYS1939:
+        is_trial: false
+    SYS1940:
+        is_trial: false
+    SYS1941:
+        is_trial: false
+    SYS1942:
+        is_trial: false
+    SYS1943:
+        is_trial: false
+    SYS1944:
+        is_trial: false
+    SYS1945:
+        is_trial: false
+    SYS1958:
+        is_trial: false
+    SYS1974:
+        is_trial: false
+    SYS2058:
+        is_trial: false
+    SYS2059:
+        is_trial: false
+    SYS2450:
+        is_trial: false
+    SYS2492:
+        is_trial: false
+    SYS2493:
+        is_trial: false
+    TRK216:
+        is_trial: false
+    TRK218:
+        is_trial: false
+    TRK218IG:
+        is_trial: false
+    TRK220:
+        is_trial: false
+    TRK220IG:
+        is_trial: false
+    TRK220IG-R4:
+        is_trial: false
+    TRK220IG-R5:
+        is_trial: false
 
 - name: subscriptions
   use_valid_acc_num: true
@@ -284,5 +547,7 @@
 
 - name: smart_management
   skus:
-    - SVC3124: {is_trial: false}
-    - RH00066: {is_trial: false}
+    SVC3124:
+        is_trial: false
+    RH00066:
+        is_trial: false

--- a/bundles/bundles.example.yml
+++ b/bundles/bundles.example.yml
@@ -1,277 +1,277 @@
 - name: ansible
   skus:
-    - MCT3691
-    - MCT3691RN
-    - MCT3691F3
-    - MCT3691F3RN
-    - MCT3691S
-    - MCT3692
-    - MCT3692RN
-    - MCT3692F3
-    - MCT3692F3RN
-    - MCT3692S
-    - MCT3693
-    - MCT3693RN
-    - MCT3693F3
-    - MCT3693F3RN
-    - MCT3693S
-    - MCT3694
-    - MCT3694RN
-    - MCT3694F3
-    - MCT3694F3RN
-    - MCT3694S
-    - MCT3695
-    - MCT3695RN
-    - MCT3695F3
-    - MCT3695F3RN
-    - MCT3695S
-    - MCT3696
-    - MCT3696RN
-    - MCT3696F3
-    - MCT3696F3RN
-    - MCT3696S
-    - MCT3733
-    - MCT3733RN
-    - MCT3733F3
-    - MCT3733F3RN
-    - MCT3733S
-    - SER0496
-    - SER0496RN
-    - SER0496F3
-    - SER0496F3RN
-    - SER0496S
-    - SER0497
-    - SER0497RN
-    - SER0497F3
-    - SER0497F3RN
-    - SER0497S
-    - SER0569
-    - SER0569RN
-    - SER0569F3
-    - SER0569F3RN
-    - SER0569S
+    - MCT3691: {is_trial: false}
+    - MCT3691RN: {is_trial: false}
+    - MCT3691F3: {is_trial: false}
+    - MCT3691F3RN: {is_trial: false}
+    - MCT3691S: {is_trial: false}
+    - MCT3692: {is_trial: false}
+    - MCT3692RN: {is_trial: false}
+    - MCT3692F3: {is_trial: false}
+    - MCT3692F3RN: {is_trial: false}
+    - MCT3692S: {is_trial: false}
+    - MCT3693: {is_trial: false}
+    - MCT3693RN: {is_trial: false}
+    - MCT3693F3: {is_trial: false}
+    - MCT3693F3RN: {is_trial: false}
+    - MCT3693S: {is_trial: false}
+    - MCT3694: {is_trial: false}
+    - MCT3694RN: {is_trial: false}
+    - MCT3694F3: {is_trial: false}
+    - MCT3694F3RN: {is_trial: false}
+    - MCT3694S: {is_trial: false}
+    - MCT3695: {is_trial: false}
+    - MCT3695RN: {is_trial: false}
+    - MCT3695F3: {is_trial: false}
+    - MCT3695F3RN: {is_trial: false}
+    - MCT3695S: {is_trial: false}
+    - MCT3696: {is_trial: false}
+    - MCT3696RN: {is_trial: false}
+    - MCT3696F3: {is_trial: false}
+    - MCT3696F3RN: {is_trial: false}
+    - MCT3696S: {is_trial: false}
+    - MCT3733: {is_trial: false}
+    - MCT3733RN: {is_trial: false}
+    - MCT3733F3: {is_trial: false}
+    - MCT3733F3RN: {is_trial: false}
+    - MCT3733S: {is_trial: false}
+    - SER0496: {is_trial: false}
+    - SER0496RN: {is_trial: false}
+    - SER0496F3: {is_trial: false}
+    - SER0496F3RN: {is_trial: false}
+    - SER0496S: {is_trial: false}
+    - SER0497: {is_trial: false}
+    - SER0497RN: {is_trial: false}
+    - SER0497F3: {is_trial: false}
+    - SER0497F3RN: {is_trial: false}
+    - SER0497S: {is_trial: false}
+    - SER0569: {is_trial: false}
+    - SER0569RN: {is_trial: false}
+    - SER0569F3: {is_trial: false}
+    - SER0569F3RN: {is_trial: false}
+    - SER0569S: {is_trial: false}
 
 - name: cost_management
   skus:
-    - MW00454
-    - MW00455
-    - MW00456
-    - MW00457
-    - MW00458
-    - MW00459
-    - MW00448
-    - MW00449
-    - MW00450
-    - MW00451
-    - MW00452
-    - MW00453
-    - MW00373
-    - MW00374
-    - MW00375
-    - MW00376
-    - MW00377
-    - MW00378
-    - MW00361
-    - MW00362
-    - MW00363
-    - MW00364
-    - MW00365
-    - MW00366
-    - MCT2735
-    - MCT2736
-    - MCT3489
-    - MCT3490
-    - MCT3753
-    - MCT3754
-    - MCT3759
-    - MCT3760
-    - MW00329
-    - MW00330
-    - MW00331
-    - MW00332
-    - MW00421
-    - MW00422
-    - MCT2862
-    - MCT2863
+    - MW00454: {is_trial: false}
+    - MW00455: {is_trial: false}
+    - MW00456: {is_trial: false}
+    - MW00457: {is_trial: false}
+    - MW00458: {is_trial: false}
+    - MW00459: {is_trial: false}
+    - MW00448: {is_trial: false}
+    - MW00449: {is_trial: false}
+    - MW00450: {is_trial: false}
+    - MW00451: {is_trial: false}
+    - MW00452: {is_trial: false}
+    - MW00453: {is_trial: false}
+    - MW00373: {is_trial: false}
+    - MW00374: {is_trial: false}
+    - MW00375: {is_trial: false}
+    - MW00376: {is_trial: false}
+    - MW00377: {is_trial: false}
+    - MW00378: {is_trial: false}
+    - MW00361: {is_trial: false}
+    - MW00362: {is_trial: false}
+    - MW00363: {is_trial: false}
+    - MW00364: {is_trial: false}
+    - MW00365: {is_trial: false}
+    - MW00366: {is_trial: false}
+    - MCT2735: {is_trial: false}
+    - MCT2736: {is_trial: false}
+    - MCT3489: {is_trial: false}
+    - MCT3490: {is_trial: false}
+    - MCT3753: {is_trial: false}
+    - MCT3754: {is_trial: false}
+    - MCT3759: {is_trial: false}
+    - MCT3760: {is_trial: false}
+    - MW00329: {is_trial: false}
+    - MW00330: {is_trial: false}
+    - MW00331: {is_trial: false}
+    - MW00332: {is_trial: false}
+    - MW00421: {is_trial: false}
+    - MW00422: {is_trial: false}
+    - MCT2862: {is_trial: false}
+    - MCT2863: {is_trial: false}
 
 - name: insights
   use_valid_acc_num: true
 
 - name: migrations
   skus:
-    - SER0584
-    - CL216
-    - CL216OS
-    - CL216VT
-    - CL218
-    - CL218IGE
-    - CL218OS
-    - CL218PT
-    - CL218VT
-    - CL220
-    - CL220IGE
-    - CL220IGE-R1
-    - CL220IGE-R2
-    - CL220IGE-R3
-    - CL220OS
-    - CL220VC
-    - ESA0017
-    - ESA0039
-    - MCT2358
-    - MCT2358F3
-    - MCT2358F3RN
-    - MCT2358RN
-    - MCT2360
-    - MCT2360F3
-    - MCT2360F3RN
-    - MCT2360RN
-    - MCT2834
-    - MCT2838
-    - MCT2838F3
-    - MCT2838F3RN
-    - MCT2838RN
-    - MCT2838S
-    - MCT2839
-    - MCT2839F3
-    - MCT2839F3RN
-    - MCT2839RN
-    - MCT2840
-    - MCT2840F3
-    - MCT2840F3RN
-    - MCT2840RN
-    - MCT2841
-    - MCT2841F3
-    - MCT2841F3RN
-    - MCT2841RN
-    - MCT2841S
-    - MCT2842
-    - MCT2842F3
-    - MCT2842F3RN
-    - MCT2842RN
-    - MCT2843
-    - MCT2843F3
-    - MCT2843F3RN
-    - MCT2843RN
-    - MCT2856
-    - MCT2856F3
-    - MCT2856F3RN
-    - MCT2856RN
-    - MCT2856S
-    - MCT2955
-    - MCT3116
-    - MCT3158
-    - MCT3159
-    - MCT3867
-    - MCT3868
-    - PT208
-    - RH00541
-    - RH00541F3
-    - RH00541F3RN
-    - RH00541RN
-    - RH00541S
-    - RH00542
-    - RH00542F3
-    - RH00542F3RN
-    - RH00542RN
-    - RH00542S
-    - RH00543
-    - RH00543F3
-    - RH00543F3RN
-    - RH00543RN
-    - RH00543S
-    - RH00544
-    - RH00544F3
-    - RH00544F3RN
-    - RH00544RN
-    - RH00544S
-    - RV00062
-    - RV00062F3
-    - RV00062F3RN
-    - RV00062RN
-    - RV00062S
-    - RV00063
-    - RV00063F3
-    - RV00063F3RN
-    - RV00063RN
-    - RV00063S
-    - RV00064
-    - RV00064F3
-    - RV00064F3RN
-    - RV00064RN
-    - RV00064S
-    - SER0407
-    - SER0408
-    - SER0412
-    - SER0430
-    - SER0431
-    - SER0432
-    - SER0433
-    - SER0442
-    - SER0583
-    - SER0584
-    - SVC1356
-    - SVC1358
-    - SVC1396
-    - SVC1885
-    - SVC1936
-    - SVC1937
-    - SVC1938
-    - SVC1939
-    - SVC1940
-    - SVC1941
-    - SVC1942
-    - SVC1943
-    - SVC1944
-    - SVC1945
-    - SVC1958
-    - SVC1974
-    - SVC2058
-    - SVC2059
-    - SVC2450
-    - SVC2492
-    - SVC2493
-    - SVC3867
-    - SVC3868
-    - SVCCL220VC
-    - SVCESA0017
-    - SVCESA0039
-    - SVCRH00541
-    - SVCRH00542
-    - SVCRH00543
-    - SVCRH00544
-    - SVCRV00062
-    - SVCRV00063
-    - SVCRV00064
-    - SVCSER0583
-    - SVCSER0584
-    - SYS1356
-    - SYS1358
-    - SYS1396
-    - SYS1885
-    - SYS1936
-    - SYS1937
-    - SYS1938
-    - SYS1939
-    - SYS1940
-    - SYS1941
-    - SYS1942
-    - SYS1943
-    - SYS1944
-    - SYS1945
-    - SYS1958
-    - SYS1974
-    - SYS2058
-    - SYS2059
-    - SYS2450
-    - SYS2492
-    - SYS2493
-    - TRK216
-    - TRK218
-    - TRK218IG
-    - TRK220
-    - TRK220IG
-    - TRK220IG-R4
-    - TRK220IG-R5
+    - SER0584: {is_trial: false}
+    - CL216: {is_trial: false}
+    - CL216OS: {is_trial: false}
+    - CL216VT: {is_trial: false}
+    - CL218: {is_trial: false}
+    - CL218IGE: {is_trial: false}
+    - CL218OS: {is_trial: false}
+    - CL218PT: {is_trial: false}
+    - CL218VT: {is_trial: false}
+    - CL220: {is_trial: false}
+    - CL220IGE: {is_trial: false}
+    - CL220IGE-R1: {is_trial: false}
+    - CL220IGE-R2: {is_trial: false}
+    - CL220IGE-R3: {is_trial: false}
+    - CL220OS: {is_trial: false}
+    - CL220VC: {is_trial: false}
+    - ESA0017: {is_trial: false}
+    - ESA0039: {is_trial: false}
+    - MCT2358: {is_trial: false}
+    - MCT2358F3: {is_trial: false}
+    - MCT2358F3RN: {is_trial: false}
+    - MCT2358RN: {is_trial: false}
+    - MCT2360: {is_trial: false}
+    - MCT2360F3: {is_trial: false}
+    - MCT2360F3RN: {is_trial: false}
+    - MCT2360RN: {is_trial: false}
+    - MCT2834: {is_trial: false}
+    - MCT2838: {is_trial: false}
+    - MCT2838F3: {is_trial: false}
+    - MCT2838F3RN: {is_trial: false}
+    - MCT2838RN: {is_trial: false}
+    - MCT2838S: {is_trial: false}
+    - MCT2839: {is_trial: false}
+    - MCT2839F3: {is_trial: false}
+    - MCT2839F3RN: {is_trial: false}
+    - MCT2839RN: {is_trial: false}
+    - MCT2840: {is_trial: false}
+    - MCT2840F3: {is_trial: false}
+    - MCT2840F3RN: {is_trial: false}
+    - MCT2840RN: {is_trial: false}
+    - MCT2841: {is_trial: false}
+    - MCT2841F3: {is_trial: false}
+    - MCT2841F3RN: {is_trial: false}
+    - MCT2841RN: {is_trial: false}
+    - MCT2841S: {is_trial: false}
+    - MCT2842: {is_trial: false}
+    - MCT2842F3: {is_trial: false}
+    - MCT2842F3RN: {is_trial: false}
+    - MCT2842RN: {is_trial: false}
+    - MCT2843: {is_trial: false}
+    - MCT2843F3: {is_trial: false}
+    - MCT2843F3RN: {is_trial: false}
+    - MCT2843RN: {is_trial: false}
+    - MCT2856: {is_trial: false}
+    - MCT2856F3: {is_trial: false}
+    - MCT2856F3RN: {is_trial: false}
+    - MCT2856RN: {is_trial: false}
+    - MCT2856S: {is_trial: false}
+    - MCT2955: {is_trial: false}
+    - MCT3116: {is_trial: false}
+    - MCT3158: {is_trial: false}
+    - MCT3159: {is_trial: false}
+    - MCT3867: {is_trial: false}
+    - MCT3868: {is_trial: false}
+    - PT208: {is_trial: false}
+    - RH00541: {is_trial: false}
+    - RH00541F3: {is_trial: false}
+    - RH00541F3RN: {is_trial: false}
+    - RH00541RN: {is_trial: false}
+    - RH00541S: {is_trial: false}
+    - RH00542: {is_trial: false}
+    - RH00542F3: {is_trial: false}
+    - RH00542F3RN: {is_trial: false}
+    - RH00542RN: {is_trial: false}
+    - RH00542S: {is_trial: false}
+    - RH00543: {is_trial: false}
+    - RH00543F3: {is_trial: false}
+    - RH00543F3RN: {is_trial: false}
+    - RH00543RN: {is_trial: false}
+    - RH00543S: {is_trial: false}
+    - RH00544: {is_trial: false}
+    - RH00544F3: {is_trial: false}
+    - RH00544F3RN: {is_trial: false}
+    - RH00544RN: {is_trial: false}
+    - RH00544S: {is_trial: false}
+    - RV00062: {is_trial: false}
+    - RV00062F3: {is_trial: false}
+    - RV00062F3RN: {is_trial: false}
+    - RV00062RN: {is_trial: false}
+    - RV00062S: {is_trial: false}
+    - RV00063: {is_trial: false}
+    - RV00063F3: {is_trial: false}
+    - RV00063F3RN: {is_trial: false}
+    - RV00063RN: {is_trial: false}
+    - RV00063S: {is_trial: false}
+    - RV00064: {is_trial: false}
+    - RV00064F3: {is_trial: false}
+    - RV00064F3RN: {is_trial: false}
+    - RV00064RN: {is_trial: false}
+    - RV00064S: {is_trial: false}
+    - SER0407: {is_trial: false}
+    - SER0408: {is_trial: false}
+    - SER0412: {is_trial: false}
+    - SER0430: {is_trial: false}
+    - SER0431: {is_trial: false}
+    - SER0432: {is_trial: false}
+    - SER0433: {is_trial: false}
+    - SER0442: {is_trial: false}
+    - SER0583: {is_trial: false}
+    - SER0584: {is_trial: false}
+    - SVC1356: {is_trial: false}
+    - SVC1358: {is_trial: false}
+    - SVC1396: {is_trial: false}
+    - SVC1885: {is_trial: false}
+    - SVC1936: {is_trial: false}
+    - SVC1937: {is_trial: false}
+    - SVC1938: {is_trial: false}
+    - SVC1939: {is_trial: false}
+    - SVC1940: {is_trial: false}
+    - SVC1941: {is_trial: false}
+    - SVC1942: {is_trial: false}
+    - SVC1943: {is_trial: false}
+    - SVC1944: {is_trial: false}
+    - SVC1945: {is_trial: false}
+    - SVC1958: {is_trial: false}
+    - SVC1974: {is_trial: false}
+    - SVC2058: {is_trial: false}
+    - SVC2059: {is_trial: false}
+    - SVC2450: {is_trial: false}
+    - SVC2492: {is_trial: false}
+    - SVC2493: {is_trial: false}
+    - SVC3867: {is_trial: false}
+    - SVC3868: {is_trial: false}
+    - SVCCL220VC: {is_trial: false}
+    - SVCESA0017: {is_trial: false}
+    - SVCESA0039: {is_trial: false}
+    - SVCRH00541: {is_trial: false}
+    - SVCRH00542: {is_trial: false}
+    - SVCRH00543: {is_trial: false}
+    - SVCRH00544: {is_trial: false}
+    - SVCRV00062: {is_trial: false}
+    - SVCRV00063: {is_trial: false}
+    - SVCRV00064: {is_trial: false}
+    - SVCSER0583: {is_trial: false}
+    - SVCSER0584: {is_trial: false}
+    - SYS1356: {is_trial: false}
+    - SYS1358: {is_trial: false}
+    - SYS1396: {is_trial: false}
+    - SYS1885: {is_trial: false}
+    - SYS1936: {is_trial: false}
+    - SYS1937: {is_trial: false}
+    - SYS1938: {is_trial: false}
+    - SYS1939: {is_trial: false}
+    - SYS1940: {is_trial: false}
+    - SYS1941: {is_trial: false}
+    - SYS1942: {is_trial: false}
+    - SYS1943: {is_trial: false}
+    - SYS1944: {is_trial: false}
+    - SYS1945: {is_trial: false}
+    - SYS1958: {is_trial: false}
+    - SYS1974: {is_trial: false}
+    - SYS2058: {is_trial: false}
+    - SYS2059: {is_trial: false}
+    - SYS2450: {is_trial: false}
+    - SYS2492: {is_trial: false}
+    - SYS2493: {is_trial: false}
+    - TRK216: {is_trial: false}
+    - TRK218: {is_trial: false}
+    - TRK218IG: {is_trial: false}
+    - TRK220: {is_trial: false}
+    - TRK220IG: {is_trial: false}
+    - TRK220IG-R4: {is_trial: false}
+    - TRK220IG-R5: {is_trial: false}
 
 - name: subscriptions
   use_valid_acc_num: true
@@ -284,5 +284,5 @@
 
 - name: smart_management
   skus:
-    - SVC3124
-    - RH00066
+    - SVC3124: {is_trial: false}
+    - RH00066: {is_trial: false}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"errors"
+	"testing"
 
 	. "github.com/RedHatInsights/entitlements-api-go/types"
 	"github.com/RedHatInsights/platform-go-middlewares/identity"
@@ -212,3 +213,16 @@ var _ = Describe("Identity Controller", func() {
 
 	})
 })
+
+func BenchmarkRequest(b *testing.B) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		fakeResponse := SubscriptionsResponse{
+			StatusCode: 200,
+			Data:       []string{"SVC123", "SVC3851", "MCT3691"},
+			CacheHit:   false,
+		}
+
+		testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "SVC3124,MCT3691", fakeResponse))
+	}
+}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -212,6 +212,34 @@ var _ = Describe("Identity Controller", func() {
 		})
 
 	})
+
+	Context("When the Subs API says we have SKUs to a Bundle", func() {
+		It("should set IsTrial to `true` when the only SKU(s) entitled are trials", func() {
+			fakeResponse := SubscriptionsResponse{
+				StatusCode: 200,
+				Data:       []string{"SVC123", "SVC3851", "MCT1122"},
+				CacheHit:   false,
+			}
+
+			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
+			expectPass(rr.Result())
+			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
+			Expect(body["TestBundle2"].IsTrial).To(Equal(true))
+		})
+
+		It("should set IsTrial to `false` when one ore more SKU(s) entitled are not trials", func() {
+			fakeResponse := SubscriptionsResponse{
+				StatusCode: 200,
+				Data:       []string{"SVC123", "SVC3851", "MCT1122", "SVC3344"},
+				CacheHit:   false,
+			}
+
+			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
+			expectPass(rr.Result())
+			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
+			Expect(body["TestBundle2"].IsTrial).To(Equal(false))
+		})
+	})
 })
 
 func BenchmarkRequest(b *testing.B) {

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -156,10 +156,8 @@ func Index() func(http.ResponseWriter, *http.Request) {
 		var skus []string
 
 		for _, bundle := range bundleInfo {
-			for _, sku := range bundle.Skus {
-				for key := range sku {
-					skus = append(skus, key)
-				}
+			for sku, _ := range bundle.Skus {
+				skus = append(skus, sku)
 			}
 		}
 
@@ -192,11 +190,8 @@ func Index() func(http.ResponseWriter, *http.Request) {
 
 			if len(bundleInfo[b].Skus) > 0 {
 				var bundleSkus []string
-
-				for _, sku := range bundleInfo[b].Skus {
-					for key := range sku {
-						bundleSkus = append(bundleSkus, key)
-					}
+				for sku, _ := range bundleInfo[b].Skus {
+					bundleSkus = append(bundleSkus, sku)
 				}
 
 				entitle = validAccNum && len(checkCommonSkus(bundleSkus, res.Data)) > 0

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -155,8 +155,12 @@ func Index() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		var skus []string
 
-		for b := range bundleInfo {
-			skus = append(skus, bundleInfo[b].Skus...)
+		for _, bundle := range bundleInfo {
+			for _, sku := range bundle.Skus {
+				for key := range sku {
+					skus = append(skus, key)
+				}
+			}
 		}
 
 		start := time.Now()
@@ -187,7 +191,15 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			entitle := true
 
 			if len(bundleInfo[b].Skus) > 0 {
-				entitle = validAccNum && len(checkCommonSkus(bundleInfo[b].Skus, res.Data)) > 0
+				var bundleSkus []string
+
+				for _, sku := range bundleInfo[b].Skus {
+					for key := range sku {
+						bundleSkus = append(bundleSkus, key)
+					}
+				}
+
+				entitle = validAccNum && len(checkCommonSkus(bundleSkus, res.Data)) > 0
 			}
 
 			if bundleInfo[b].UseValidAccNum {

--- a/test_data/test_bundle.yml
+++ b/test_data/test_bundle.yml
@@ -1,13 +1,13 @@
 - name: TestBundle1
   skus:
-    - SVC123
-    - SVC456
-    - MCT789
+    - SVC123: {is_trial: false}
+    - SVC456: {is_trial: false}
+    - MCT789: {is_trial: false}
 
 - name: TestBundle2
   skus:
-    - MCT1122
-    - SVC3344
+    - MCT1122: {is_trial: false}
+    - SVC3344: {is_trial: false}
 
 - name: TestBundle3
   use_valid_acc_num: false

--- a/test_data/test_bundle.yml
+++ b/test_data/test_bundle.yml
@@ -1,13 +1,19 @@
 - name: TestBundle1
   skus:
-    - SVC123: {is_trial: false}
-    - SVC456: {is_trial: false}
-    - MCT789: {is_trial: false}
+    SVC123:
+      is_trial: false
+    SVC456:
+      is_trial: false
+    MCT789:
+      is_trial: false
+
 
 - name: TestBundle2
   skus:
-    - MCT1122: {is_trial: false}
-    - SVC3344: {is_trial: false}
+    MCT1122:
+      is_trial: true
+    SVC3344:
+      is_trial: false
 
 - name: TestBundle3
   use_valid_acc_num: false

--- a/types/main.go
+++ b/types/main.go
@@ -29,10 +29,18 @@ type SubscriptionDetails struct {
 
 // Bundle is a struct that is used to unmarshal the bundle info from bundles.yml
 type Bundle struct {
-	Name           string   `yaml:"name"`
-	UseValidAccNum bool     `yaml:"use_valid_acc_num"`
-	Skus           []string `yaml:"skus"`
+	Name           string `yaml:"name"`
+	UseValidAccNum bool   `yaml:"use_valid_acc_num"`
+	Skus           []Skus `yaml:"skus"`
 }
+
+// SkuAttributes is a struct that is used to unmarshal the sku data in a bundle
+type SkuAttributes struct {
+	IsTrial bool `yaml:"is_trial"`
+}
+
+// Skus is a struct that is used to unmarshal a map of SkuAttributes
+type Skus map[string]SkuAttributes
 
 // DependencyErrorDetails is a struct that is used to marshal failure details
 // from failed requests to the subscriptions service

--- a/types/main.go
+++ b/types/main.go
@@ -31,7 +31,7 @@ type SubscriptionDetails struct {
 type Bundle struct {
 	Name           string `yaml:"name"`
 	UseValidAccNum bool   `yaml:"use_valid_acc_num"`
-	Skus           []Skus `yaml:"skus"`
+	Skus           Skus   `yaml:"skus"`
 }
 
 // SkuAttributes is a struct that is used to unmarshal the sku data in a bundle

--- a/types/main.go
+++ b/types/main.go
@@ -1,8 +1,9 @@
 package types
 
-// EntitlementsSection is a struct representing { "is_entitled": bool } on the SubscriptionsResponse
+// EntitlementsSection is a struct representing { "is_entitled": bool, "is_trial": bool } on the SubscriptionsResponse
 type EntitlementsSection struct {
 	IsEntitled bool `json:"is_entitled"`
+	IsTrial    bool `json:"is_trial"`
 }
 
 // SubscriptionsResponse is a struct that is used to unmarshal the data that comes back from the


### PR DESCRIPTION
## Jira
- [Enhance entitlements API to return trial SKU information](https://projects.engineering.redhat.com/browse/RHCLOUD-6631)

## Intent of Changes
In order to have explicit behavior from a UX perspective on cloud.redhat.com bundles
for those accounts which have "trial" SKUs, we need a way to inform the client
of the entitlements service whether or not the user is being entitled to the bundle
with a trial or set of trial SKUs.

By default, this value will be set to `false`, and always returned in the payload
for sake of contract consistency, even on bundles which do not entitle based on
SKUs.

There is currently no way to determine which SKUs are "trial" from the subscription
service. This change will rely on bundle teams/owners to update their SKU list
to set their trial SKUs. Note that this will require and be dependent on a config
change in https://github.com/RedHatInsights/entitlements-config in order to restructure
the yaml to be supported by the code changes in this PR. 

In order to deploy these changes we'll likely need to pause rollouts, deploy the 
config changes, and then deploy the code which will ensure that the config sync 
job does not trigger a new deployment which would break the contract between the config and code.

When we iterate over the user's entitled SKUs to determine the intersection between
those and the bundle SKUs to see if they're entitled to the bundle, we'll also
reference the bundle SKUs to see if the SKU is a trial SKU. If it is, we'll bucket
the SKU, and once we're complete, we'll compare the list of user SKUs to the trial
SKUs. In the case where all SKUs are trial SKUs, we set `is_trial` to `true` in
the response payload. In the case where there is at least one non-trial SKU, or
no SKUs at all, we will set `is_trial` to `false.

The resulting payload will look something like:
```
{
  "ansible": {
    "is_entitled": true,
    "is_trial": true
  },
  "cost_management": {
    "is_entitled": true,
    "is_trial": false
  },...
}
```

There is also an added benchmark with README updates on how to run benchmarks
in the test suite: `go test -bench=.` from within `/controllers/`

In response to this change, we need to update the code to unmarshal and consume
the config differently. We do this by introducing a new `SkuAttributes` type,
as well as a new `Skus` type, which is a map of `SkuAttributes` with dynamic keys.

## Local Testing
You will need to update your local `/bundles/bundle.yml` file to adhere to the new
format in `/bundles/bundle.example.yml` in order for this to work locally.

Otherwise you should be able to use/test the service as you normally would.

To validate the changes, look at the tests and how they're setup to include/exclude
SKUs to determine the flag value. You can also change your local `/bundles/bundle.yml`
file to set one bundle to have all SKUs set to `is_trial: true`. Then when you
run the service locally, assuming you're entitled to the bundle, you should see
the value `is_trial` equal to `true` in your response.


## Checklist
- [x] are there any pre/post merge actions required? if so, document here.

- [x] are theses changes covered by unit tests?

- [x] if warranted, are documentation changes accounted for?
Documentation changes will be required in https://github.com/RedHatInsights/entitlements-config
