### PR TITLE
Ensure that we don't set `is_trial: true` when there are no SKUs

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -239,6 +239,21 @@ var _ = Describe("Identity Controller", func() {
 			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
 			Expect(body["TestBundle2"].IsTrial).To(Equal(false))
 		})
+
+		It("should set IsTrial to `false` when the user is not entitled because they have no SKUs", func() {
+			fakeResponse := SubscriptionsResponse{
+				StatusCode: 200,
+				Data:       []string{},
+				CacheHit:   false,
+			}
+
+			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
+			expectPass(rr.Result())
+			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
+			Expect(body["TestBundle2"].IsTrial).To(Equal(false))
+			Expect(body["TestBundle1"].IsEntitled).To(Equal(false))
+			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
+		})
 	})
 })
 

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -197,7 +197,10 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			if len(bundleInfo[b].Skus) > 0 {
 				commonSKUs, trialSKUs := commonAndTrialSKUs(b, res.Data)
 				entitle = (validAccNum && len(commonSKUs) > 0)
-				trial = onlyHasTrialSkus(commonSKUs, trialSKUs)
+
+				if len(trialSKUs) > 0 {
+					trial = onlyHasTrialSkus(commonSKUs, trialSKUs)
+				}
 			}
 
 			if bundleInfo[b].UseValidAccNum {


### PR DESCRIPTION
In the case where a user has no SKUs (and no trial SKUs), the `len()` check against
the number of common and trial SKUs would evaluate to `true`, since they would
both be 0.

This was causing bundles which the user was not entitled to, to always return
true for `is_trial`.

This fixes that by only doing the length comparison if there is a positive number
of trial SKUs. Otherwise, `is_trial` should remain `false`.