### PR TITLE
Add simple /status endpoing for liveness check

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -1,0 +1,53 @@
+package controllers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/RedHatInsights/entitlements-api-go/config"
+	"github.com/go-chi/chi"
+)
+
+type info struct {
+	Version string `json:"version"`
+}
+
+type spec struct {
+	Info info `json:"info"`
+}
+
+type statusInfo struct {
+	APIVersion string `json:"apiVersion"`
+	Commit     string `json:"commit"`
+}
+
+func buildStatus() statusInfo {
+	specFilePath := config.GetConfig().Options.GetString(config.Keys.OpenAPISpecPath)
+	specFile, err := ioutil.ReadFile(specFilePath)
+
+	apiVersion := ""
+
+	var s spec
+
+	if err == nil {
+		err := json.Unmarshal(specFile, &s)
+		if err == nil {
+			apiVersion = s.Info.Version
+		}
+	}
+
+	status := statusInfo{}
+	status.APIVersion = apiVersion
+	status.Commit = os.Getenv("OPENSHIFT_BUILD_COMMIT")
+
+	return status
+}
+
+// Status responds back with service status information
+func Status(r chi.Router) {
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(buildStatus())
+	})
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -25,8 +25,9 @@ func DoRoutes() chi.Router {
 		r.With(identity.EnforceIdentity).Route("/", controllers.LubDub)
 		r.Route("/openapi.json", apispec.OpenAPISpec)
 		r.With(identity.EnforceIdentity).Get("/services", controllers.Index())
-		r.Route("/status", controllers.Status)
 	})
+
+	r.Route("/status", controllers.Status)
 
 	return r
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	chilogger "github.com/766b/chi-logger"
 	"github.com/RedHatInsights/entitlements-api-go/apispec"
 	"github.com/RedHatInsights/entitlements-api-go/controllers"
 	log "github.com/RedHatInsights/entitlements-api-go/logger"
 	"github.com/RedHatInsights/platform-go-middlewares/identity"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/766b/chi-logger"
 )
 
 // DoRoutes sets up the routes used by the server.

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,13 +1,13 @@
 package server
 
 import (
+	chilogger "github.com/766b/chi-logger"
 	"github.com/RedHatInsights/entitlements-api-go/apispec"
 	"github.com/RedHatInsights/entitlements-api-go/controllers"
 	log "github.com/RedHatInsights/entitlements-api-go/logger"
 	"github.com/RedHatInsights/platform-go-middlewares/identity"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
-	"github.com/766b/chi-logger"
 )
 
 // DoRoutes sets up the routes used by the server.
@@ -25,6 +25,7 @@ func DoRoutes() chi.Router {
 		r.With(identity.EnforceIdentity).Route("/", controllers.LubDub)
 		r.Route("/openapi.json", apispec.OpenAPISpec)
 		r.With(identity.EnforceIdentity).Get("/services", controllers.Index())
+		r.Route("/status", controllers.Status)
 	})
 
 	return r


### PR DESCRIPTION
Try to grab the apiversion from the openapi spec, but don't error out if
we can't get, it's not vital, and the actual spec endpoint has error
handling if we can't read the file. Just a nice-to-have here.

Signed-off-by: Chris Mitchell <cmitchel@redhat.com>

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [x] File Management

- [ ] Memory Management

- [ ] General Coding Practices
