### PR TITLE
Use new it features api

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -41,7 +41,7 @@ func testRequest(method string, path string, accnum string, orgid string, isinte
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
 
-	GetSubscriptions = fakeCaller
+	GetFeatureStatus = fakeCaller
 
 	Index()(rr, req)
 
@@ -60,7 +60,7 @@ func testRequestWithDefaultOrgId(method string, path string, fakeCaller func(str
 	return testRequest(method, path, DEFAULT_ACCOUNT_NUMBER, DEFAULT_ORG_ID, DEFAULT_IS_INTERNAL, DEFAULT_EMAIL, fakeCaller)
 }
 
-func fakeGetSubscriptions(expectedOrgID string, expectedSkus string, response SubscriptionsResponse) func(string, string) SubscriptionsResponse {
+func fakeGetFeatureStatus(expectedOrgID string, expectedSkus string, response SubscriptionsResponse) func(string, string) SubscriptionsResponse {
 	return func(orgID string, skus string) SubscriptionsResponse {
 		Expect(expectedOrgID).To(Equal(orgID))
 		return response
@@ -81,20 +81,20 @@ var _ = Describe("Identity Controller", func() {
 		}
 	})
 
-	It("should call GetSubscriptions with the org_id on the context", func() {
+	It("should call GetFeatureStatus with the org_id on the context", func() {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       []string{"foo", "bar"},
+			Data:       FeatureStatus{},
 			CacheHit:   false,
 		}
-		testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "540155", DEFAULT_IS_INTERNAL, DEFAULT_EMAIL, fakeGetSubscriptions("540155", "", fakeResponse))
-		testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "deadbeef12", DEFAULT_IS_INTERNAL, DEFAULT_EMAIL, fakeGetSubscriptions("deadbeef12", "", fakeResponse))
+		testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "540155", DEFAULT_IS_INTERNAL, DEFAULT_EMAIL, fakeGetFeatureStatus("540155", "", fakeResponse))
+		testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "deadbeef12", DEFAULT_IS_INTERNAL, DEFAULT_EMAIL, fakeGetFeatureStatus("deadbeef12", "", fakeResponse))
 	})
 
 	Context("When the Subs API sends back a non-200", func() {
 		It("should fail the response", func() {
 			rr, _, rawBody := testRequestWithDefaultOrgId("GET", "/", func(string, string) SubscriptionsResponse {
-				return SubscriptionsResponse{StatusCode: 503, Data: nil, CacheHit: false}
+				return SubscriptionsResponse{StatusCode: 503, Data: FeatureStatus{}, CacheHit: false}
 			})
 
 			var jsonResponse DependencyErrorResponse
@@ -112,7 +112,7 @@ var _ = Describe("Identity Controller", func() {
 	Context("When the Subs API sends back an error", func() {
 		It("should fail the response", func() {
 			rr, _, rawBody := testRequestWithDefaultOrgId("GET", "/", func(string, string) SubscriptionsResponse {
-				return SubscriptionsResponse{StatusCode: 503, Data: nil, CacheHit: false, Error: errors.New("Sub Failure")}
+				return SubscriptionsResponse{StatusCode: 503, Data: FeatureStatus{}, CacheHit: false, Error: errors.New("Sub Failure")}
 			})
 
 			var jsonResponse DependencyErrorResponse
@@ -143,45 +143,16 @@ var _ = Describe("Identity Controller", func() {
 		})
 	})
 
-	Context("When the Subs API says we have SKUs to a Bundle", func() {
-		It("should give back a valid EntitlementsResponse with that bundle true", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{"SVC123", "SVC3851", "MCT3691"},
-				CacheHit:   false,
-			}
-
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "SVC3124,MCT3691", fakeResponse))
-			expectPass(rr.Result())
-			Expect(body["TestBundle1"].IsEntitled).To(Equal(true))
-		})
-	})
-
-	Context("When the Subs API says we *dont* have SKUs to a Bundle", func() {
-		It("should give back a valid EntitlementsResponse with that bundle true", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{"SVC123", "SVC3851", "MCT3691"},
-				CacheHit:   false,
-			}
-
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "SVC3124,MCT3691", fakeResponse))
-			expectPass(rr.Result())
-			Expect(body["TestBundle1"].IsEntitled).To(Equal(true))
-			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
-		})
-	})
-
 	Context("When the account number is -1 or '' ", func() {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       []string{"SVC123", "MCT1122", "SVC7788"},
+			Data:       FeatureStatus{},
 			CacheHit:   false,
 		}
 
 		It("should give back a valid EntitlementsResponse with bundles using Valid Account Number false", func() {
 			// testing with account number "-1"
-			rr, body, _ := testRequest("GET", "/", "-1", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+			rr, body, _ := testRequest("GET", "/", "-1", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle1"].IsEntitled).To(Equal(false))
 			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
@@ -192,7 +163,7 @@ var _ = Describe("Identity Controller", func() {
 
 		It("should give back a valid EntitlementsResponse with bundles using Valid Account Number false", func() {
 			// testing with account number ""
-			rr, body, _ := testRequest("GET", "/", "", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+			rr, body, _ := testRequest("GET", "/", "", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle1"].IsEntitled).To(Equal(false))
 			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
@@ -205,13 +176,13 @@ var _ = Describe("Identity Controller", func() {
 	Context("When a bundle uses only Valid Account Number", func() {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       []string{},
+			Data:       FeatureStatus{},
 			CacheHit:   false,
 		}
 
 		It("should give back a valid EntitlementsResponse with that bundle true", func() {
 			// testing with account number ""
-			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle1"].IsEntitled).To(Equal(false))
 			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
@@ -222,84 +193,65 @@ var _ = Describe("Identity Controller", func() {
 
 	})
 
-	Context("When a bundle uses only use_is_inernal", func() {
+	Context("When a bundle uses only use_is_internal", func() {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       []string{"SVC123", "MCT1122", "SVC7788"},
+			Data:       FeatureStatus{},
 			CacheHit:   false,
 		}
 
-		It("should entitle when valid account and principal is inernal", func() {
-			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+		It("should entitle when valid account and principal is internal", func() {
+			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle5"].IsEntitled).To(Equal(true))
 		})
 
-		It("should not entitle when valid account and principal is inernal but email is not @redhat.com", func() {
-			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, "jdoe@example.com", fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+		It("should not entitle when valid account and principal is internal but email is not @redhat.com", func() {
+			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, "jdoe@example.com", fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle5"].IsEntitled).To(Equal(false))
 		})
 
-		It("should not entitle when valid account and principal is not inernal", func() {
-			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, false, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+		It("should not entitle when valid account and principal is not internal", func() {
+			rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, false, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle5"].IsEntitled).To(Equal(false))
 		})
 
-		It("should not entitle when not a valid account and principal is inernal", func() {
-			rr, body, _ := testRequest("GET", "/", "", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+		It("should not entitle when not a valid account and principal is internal", func() {
+			rr, body, _ := testRequest("GET", "/", "", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle5"].IsEntitled).To(Equal(false))
 		})
 
-		It("should not entitle when not a valid account and principal is inernal", func() {
-			rr, body, _ := testRequest("GET", "/", "-1", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetSubscriptions(DEFAULT_ORG_ID, "test", fakeResponse))
+		It("should not entitle when not a valid account and principal is internal", func() {
+			rr, body, _ := testRequest("GET", "/", "-1", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, "test", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle5"].IsEntitled).To(Equal(false))
 		})
 	})
 
-	Context("When the Subs API says we have SKUs to a Bundle", func() {
-		It("should set IsTrial to `true` when the only SKU(s) entitled are trials", func() {
+	Context("When the Subscriptions API returns features", func() {
+		It("should set values based on response from the featureStatus request", func() {
 			fakeResponse := SubscriptionsResponse{
 				StatusCode: 200,
-				Data:       []string{"SVC123", "SVC3851", "MCT1122"},
+				Data:       FeatureStatus{
+					[]Feature{
+						{ Name: "TestBundle1", IsEval: false, Entitled: false },
+						{ Name: "TestBundle2", IsEval: true,  Entitled: true },
+					},
+				},
 				CacheHit:   false,
 			}
 
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
+			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetFeatureStatus(DEFAULT_ORG_ID, "", fakeResponse))
 			expectPass(rr.Result())
 			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
 			Expect(body["TestBundle2"].IsTrial).To(Equal(true))
-		})
-
-		It("should set IsTrial to `false` when one ore more SKU(s) entitled are not trials", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{"SVC123", "SVC3851", "MCT1122", "SVC3344"},
-				CacheHit:   false,
-			}
-
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
-			expectPass(rr.Result())
-			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
-			Expect(body["TestBundle2"].IsTrial).To(Equal(false))
-		})
-
-		It("should set IsTrial to `false` when the user is not entitled because they have no SKUs", func() {
-			fakeResponse := SubscriptionsResponse{
-				StatusCode: 200,
-				Data:       []string{},
-				CacheHit:   false,
-			}
-
-			rr, body, _ := testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "", fakeResponse))
-			expectPass(rr.Result())
-			Expect(body["TestBundle1"].IsTrial).To(Equal(false))
-			Expect(body["TestBundle2"].IsTrial).To(Equal(false))
+			Expect(body["TestBundle6"].IsTrial).To(Equal(false))
 			Expect(body["TestBundle1"].IsEntitled).To(Equal(false))
-			Expect(body["TestBundle2"].IsEntitled).To(Equal(false))
+			Expect(body["TestBundle2"].IsEntitled).To(Equal(true))
+			Expect(body["TestBundle6"].IsEntitled).To(Equal(false))
 		})
 	})
 })
@@ -309,10 +261,10 @@ func BenchmarkRequest(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       []string{"SVC123", "SVC3851", "MCT3691"},
+			Data:       FeatureStatus{},
 			CacheHit:   false,
 		}
 
-		testRequestWithDefaultOrgId("GET", "/", fakeGetSubscriptions(DEFAULT_ORG_ID, "SVC3124,MCT3691", fakeResponse))
+		testRequestWithDefaultOrgId("GET", "/", fakeGetFeatureStatus(DEFAULT_ORG_ID, "SVC3124,MCT3691", fakeResponse))
 	}
 }

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -157,13 +157,9 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			if len(b.Skus) > 0 {
 				entitle = false
 				for _, f := range res.Data.Features {
-					name := f.Name
-					isEval := f.IsEval
-					entitled := f.Entitled
-
-					if name == b.Name {
-						entitle = entitled
-						trial = isEval
+					if f.Name == b.Name {
+						entitle = f.Entitled
+						trial = f.IsEval
 					}
 				}
 			}

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -53,23 +53,25 @@ func SetBundleInfo(yamlFilePath string) error {
 	return nil
 }
 
-// GetSubscriptions calls the Subs service and returns the SKUs the user has
-var GetSubscriptions = func(orgID string, skus string) types.SubscriptionsResponse {
+// GetFeatureStatus calls the IT subs service features endpoint and returns the entitlements for specified features/bundles
+var GetFeatureStatus = func(orgID string, skus string) types.SubscriptionsResponse {
 	item := cache.Get(orgID)
 
 	if item != nil && !item.Expired() {
 		return types.SubscriptionsResponse{
 			StatusCode: 200,
-			Data:       item.Value().([]string),
+			Data:       item.Value().(types.FeatureStatus),
 			CacheHit:   true,
 		}
 	}
 
-	resp, err := getClient().Get(config.GetConfig().Options.GetString(config.Keys.SubsHost) +
-		"/svcrest/subscription/v5/searchnested/criteria" +
-		";web_customer_id=" + orgID +
-		";sku=" + skus +
-		";/options;products=ALL/product.sku|product.statusCode")
+	q := config.GetConfig().Options.GetString(config.Keys.FeaturesPath)
+	req := config.GetConfig().Options.GetString(config.Keys.SubsHost) +
+		"/svcrest/subscription/v5/featureStatus" +
+		q + "&accountId=" + orgID
+
+
+	resp, err := getClient().Get(req)
 
 	if err != nil {
 		return types.SubscriptionsResponse{
@@ -84,61 +86,25 @@ var GetSubscriptions = func(orgID string, skus string) types.SubscriptionsRespon
 			StatusCode: resp.StatusCode,
 			Body:       string(body),
 			Error:      nil,
-			Data:       nil,
+			Data:       types.FeatureStatus{},
 			CacheHit:   false,
 		}
 	}
 
 	defer resp.Body.Close()
-	var arr []string
 
-	// Unmarshaling response from Subscription
-	// Extracting skus and appending them to arr
+	// Unmarshaling response from Feature service
 	body, _ := ioutil.ReadAll(resp.Body)
-	var SubscriptionDetails []types.SubscriptionDetails
-	json.Unmarshal(body, &SubscriptionDetails)
+	var FeatureStatus types.FeatureStatus
+	json.Unmarshal(body, &FeatureStatus)
 
-	for s := range SubscriptionDetails {
-		skuInfo := SubscriptionDetails[s].Entries
-		skuName := skuInfo[0].Value
-		skuStatus := strings.ToLower(skuInfo[1].Value)
-		// sku status == "" means it's a parent SKU
-		if skuStatus == "" || skuStatus == "active" || skuStatus == "temporary" {
-			arr = append(arr, skuName)
-		}
-	}
-
-	cache.Set(orgID, arr, time.Minute*10)
+	cache.Set(orgID, FeatureStatus, time.Minute*10)
 
 	return types.SubscriptionsResponse{
 		StatusCode: resp.StatusCode,
-		Data:       arr,
+		Data:       FeatureStatus,
 		CacheHit:   false,
 	}
-}
-
-// Checks the common strings between two slices of strings and returns a slice of strings
-// with the common skus, as well as the subset of trial SKUs
-func commonAndTrialSKUs(b int, userSkus []string) ([]string, []string) {
-	var commonSKUs []string
-	var trialSKUs []string
-
-	skus := bundleInfo[b].Skus
-
-	for _, usku := range userSkus {
-		if _, found := skus[usku]; found {
-			commonSKUs = append(commonSKUs, usku)
-			if skus[usku].IsTrial {
-				trialSKUs = append(trialSKUs, usku)
-			}
-		}
-	}
-
-	return commonSKUs, trialSKUs
-}
-
-func onlyHasTrialSkus(commonSKUs []string, trialSKUs []string) bool {
-	return len(commonSKUs) == len(trialSKUs)
 }
 
 func failOnDependencyError(errMsg string, res types.SubscriptionsResponse, w http.ResponseWriter) {
@@ -169,7 +135,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 
 		start := time.Now()
 		idObj := identity.Get(req.Context()).Identity
-		res := GetSubscriptions(idObj.Internal.OrgID, strings.Join(skus, ","))
+		res := GetFeatureStatus(idObj.Internal.OrgID, strings.Join(skus, ","))
 		accNum := idObj.AccountNumber
 		isInternal := idObj.User.Internal
 		validEmailMatch, _ := regexp.MatchString(`^.*@redhat.com$`, idObj.User.Email)
@@ -193,27 +159,32 @@ func Index() func(http.ResponseWriter, *http.Request) {
 		}
 
 		entitlementsResponse := make(map[string]types.EntitlementsSection)
-		for b := range bundleInfo {
+		for _, b := range bundleInfo {
 			entitle := true
 			trial := false
 
-			if len(bundleInfo[b].Skus) > 0 {
-				commonSKUs, trialSKUs := commonAndTrialSKUs(b, res.Data)
-				entitle = (validAccNum && len(commonSKUs) > 0)
+			if len(b.Skus) > 0 {
+				entitle = false
+				for _, f := range res.Data.Features {
+					name := f.Name
+					isEval := f.IsEval
+					entitled := f.Entitled
 
-				if len(trialSKUs) > 0 {
-					trial = onlyHasTrialSkus(commonSKUs, trialSKUs)
+					if name == b.Name {
+						entitle = entitled
+						trial = isEval
+					}
 				}
 			}
 
-			if bundleInfo[b].UseValidAccNum {
+			if b.UseValidAccNum {
 				entitle = validAccNum && entitle
 			}
 
-			if bundleInfo[b].UseIsInternal {
+			if b.UseIsInternal {
 				entitle = validAccNum && isInternal && validEmailMatch
 			}
-			entitlementsResponse[bundleInfo[b].Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+			entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
 		}
 
 		obj, err := json.Marshal(entitlementsResponse)

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 	"regexp"
 
@@ -54,7 +53,7 @@ func SetBundleInfo(yamlFilePath string) error {
 }
 
 // GetFeatureStatus calls the IT subs service features endpoint and returns the entitlements for specified features/bundles
-var GetFeatureStatus = func(orgID string, skus string) types.SubscriptionsResponse {
+var GetFeatureStatus = func(orgID string) types.SubscriptionsResponse {
 	item := cache.Get(orgID)
 
 	if item != nil && !item.Expired() {
@@ -125,17 +124,9 @@ func failOnDependencyError(errMsg string, res types.SubscriptionsResponse, w htt
 // Index the handler for GETs to /api/entitlements/v1/services/
 func Index() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		var skus []string
-
-		for _, bundle := range bundleInfo {
-			for sku, _ := range bundle.Skus {
-				skus = append(skus, sku)
-			}
-		}
-
 		start := time.Now()
 		idObj := identity.Get(req.Context()).Identity
-		res := GetFeatureStatus(idObj.Internal.OrgID, strings.Join(skus, ","))
+		res := GetFeatureStatus(idObj.Internal.OrgID)
 		accNum := idObj.AccountNumber
 		isInternal := idObj.User.Internal
 		validEmailMatch, _ := regexp.MatchString(`^.*@redhat.com$`, idObj.User.Email)

--- a/test_data/test_bundle.yml
+++ b/test_data/test_bundle.yml
@@ -23,3 +23,12 @@
 
 - name: TestBundle5
   use_is_internal: true
+
+- name: TestBundle6
+  skus:
+    SVC321:
+      is_trial: false
+    SVC654:
+      is_trial: false
+    MCT987:
+      is_trial: false

--- a/types/main.go
+++ b/types/main.go
@@ -12,7 +12,7 @@ type SubscriptionsResponse struct {
 	StatusCode int
 	Body       string
 	Error      error
-	Data       []string
+	Data       FeatureStatus
 	CacheHit   bool
 }
 
@@ -20,6 +20,16 @@ type SubscriptionsResponse struct {
 // response of the Subscription Service
 type Entries struct {
 	Value string
+}
+
+type Feature struct {
+	Name string   `json:"name"`
+	IsEval bool   `json:"isEval"`
+	Entitled bool `json:"entitled"`
+}
+
+type FeatureStatus struct {
+	Features []Feature `json:"features"`
 }
 
 // SubscriptionDetails is a struct that is used to unmarshal the data that comes back in the Body


### PR DESCRIPTION
**Epic:** https://issues.redhat.com/browse/RHCLOUD-9584

**Background:**
For managing entitlements, we currently have a ceiling of ~850 SKUs which we can
supply to the subscriptions service before we start receiving 400s.

Currently we are manually collecting all SKUs we care about, and passing them to
the subscriptions service: https://github.com/RedHatInsights/entitlements-api-go/blob/4aeef647cabda3341889661f2d487c751fbc239a/controllers/subscriptions.go#L67

Now that IT has provided a `/features` and `/featureStatus` endpoint on the subscriptions
service, we should integrate with it in order to have IT be the source of truth
for telling us whether or not a principal is entitled to a particular feature/bundle
based on their subscriptions, and if that entitlement is a trial/eval or not.

We will still be the source of truth for defining which SKUs each feature/bundle is
represented by, and will push those changes from our config repo into their API.
This will come in the future via: https://issues.redhat.com/browse/RHCLOUD-12009

For now, our bundles are already seeded in all environments based on the current
state: https://github.com/RedHatInsights/entitlements-config/tree/640579dffd0aea66fa970d056627a18f7cd8a178

**Note:** If this state changes prior to automation, we'll need to manually
update the `/features/ansible` or `/features/smart_management` feature in IT
to reflect the latest, so that when we call `/featureStatus/?features=ansible&features=smart_management`
we ensure IT is checking the most recent SKU changes.

**Changes:**
In order to specify the features for the query params to the new endpoint, we've
exposed `ENT_FEATURES` which can be a comma-separated string of values. By default,
this will be set to `ansible,smart_management` but can be configured in the above
environment variable as well.

The `org_id` from the identity header will again be used, so a request will look
something like:
```
https://subscription.api.redhat.com/svcrest/subscription/v5/featureStatus?accountId=<ACCOUNT_ID>&features=ansible&features=smart_management
```

When we get a response back, we'll unmarshal the body into a new `FeatureStatus`
struct. Instead of looping through SKUs from the subs service to determine if a
principal's subs match any SKU in a bundle, we'll let IT handle that and reply
back. Now, we'll get a response similar to:
```
{
  "features": [
    {
      "name": "ansible",
      "isEval": false,
      "entitled": true
    },
    {
      "name": "smart_management",
      "isEval": false,
      "entitled": true
    }
  ]
}
```
We'll use the names of the features (filtered by our query) to match against our
bundles, and when we find a match, set the `is_trial` and `is_entitled` flags
based on that response.

One change is that for these bundle SKUs, we'll default the `is_entitled` flag
to `false` to deny by default.

**Testing:**
This should be easily testable, similar to the old implementation, as the API contract
for this service will not change, so it should be a 1-1 swap. You can verify what
the features have in them by using one of the following `GET` request endpoints (with certs):
```
https://subscription.qa.api.redhat.com/svcrest/subscription/v5/features/ansible
https://subscription.qa.api.redhat.com/svcrest/subscription/v5/features/smart_management
https://subscription.qa.api.redhat.com/svcrest/subscription/v5/features
```

**Future Changes/Considerations:**
- We'll still need to use our bundle files for other non-SKU bundles local to the
  service (and for determining which bundles to check IT features for)
- Maybe we should update the SKU-based bundles to have a "use_feature_status" flag,
  so we can use that vs checking SKUS > 0 in our logic.
- We'll want to pull out the `is_trial` flag and reformat the SKU-based bundles
  since we no longer need that. It's non-breaking as is, however.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
