### PR TITLE
Fixes to allow Sentry to report panics and other events

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 
 	// init config here
 	if err := controllers.SetBundleInfo(config.GetConfig().Options.GetString(config.Keys.BundleInfoYaml)); err != nil {
+		sentry.CaptureException(err)
 		logger.Log.WithFields(logrus.Fields{"error": err}).Fatal("Error reading bundles.yml")
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/766b/chi-logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	sentryhttp "github.com/getsentry/sentry-go/http"
 )
 
 // DoRoutes sets up the routes used by the server.
@@ -17,10 +18,15 @@ import (
 func DoRoutes() chi.Router {
 	r := chi.NewRouter()
 
+	sentryMiddleware := sentryhttp.New(sentryhttp.Options{
+		Repanic: true,
+	})
+
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(chilogger.NewLogrusMiddleware("router", log.Log))
+	r.Use(sentryMiddleware.Handle)
 
 	r.Route("/api/entitlements/v1", func(r chi.Router) {
 		r.With(identity.EnforceIdentity).Route("/", controllers.LubDub)


### PR DESCRIPTION
In order for Sentry to start reporting error events, we need to do a few things:

- Include the sentry-http handler as middleware. This will catch any panics.
  We'll set `Repanic: true` which ensure the panic will still be raised.
- Explicitly capture exceptions as we catch them in the app.
- In the event we don't have an exception, create one and add some context with
  `sentry.WithScope` to ensure we get more than just a custom error message.

Resources:
- https://pkg.go.dev/github.com/getsentry/sentry-go@v0.10.0/http
- https://gist.github.com/rhcarvalho/66130d1252d4a7b1fbaeacfe3687eaf3

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
