### PR TITLE
Add Prometheus histogram for subs time taken

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -264,10 +264,12 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=


### PR DESCRIPTION
In order to get visibility on latency from the subscriptions service, we should
add a histogram around the time taken (which we currently already log).

The following sets the buckets for our histogram:
```
Buckets: prometheus.LinearBuckets(0.25, 0.25, 20),
```

This equats to `start value`, `interval`, and `count`. Meaning we'll have
20 buckets, starting at 0.25 seconds in intervals of 0.25 seconds.

These metrics will be exposed on `/metrics` as:
```
# HELP it_subscriptions_service_time_taken Subscriptions latency distributions.
# TYPE it_subscriptions_service_time_taken histogram
it_subscriptions_service_time_taken_bucket{le="0.25"} 0
it_subscriptions_service_time_taken_bucket{le="0.5"} 0
it_subscriptions_service_time_taken_bucket{le="0.75"} 0
it_subscriptions_service_time_taken_bucket{le="1"} 0
it_subscriptions_service_time_taken_bucket{le="1.25"} 0
it_subscriptions_service_time_taken_bucket{le="1.5"} 1
it_subscriptions_service_time_taken_bucket{le="1.75"} 1
it_subscriptions_service_time_taken_bucket{le="2"} 1
it_subscriptions_service_time_taken_bucket{le="2.25"} 1
it_subscriptions_service_time_taken_bucket{le="2.5"} 1
it_subscriptions_service_time_taken_bucket{le="2.75"} 1
it_subscriptions_service_time_taken_bucket{le="3"} 1
it_subscriptions_service_time_taken_bucket{le="3.25"} 1
it_subscriptions_service_time_taken_bucket{le="3.5"} 1
it_subscriptions_service_time_taken_bucket{le="3.75"} 1
it_subscriptions_service_time_taken_bucket{le="4"} 1
it_subscriptions_service_time_taken_bucket{le="4.25"} 1
it_subscriptions_service_time_taken_bucket{le="4.5"} 1
it_subscriptions_service_time_taken_bucket{le="4.75"} 1
it_subscriptions_service_time_taken_bucket{le="5"} 1
it_subscriptions_service_time_taken_bucket{le="+Inf"} 1
it_subscriptions_service_time_taken_sum 1.375526029
it_subscriptions_service_time_taken_count 1
```