### PR TITLE
Bump Golang version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12.x
+  - 1.13.x
 
 before_install:
   - export GO111MODULE="on"


### PR DESCRIPTION
This should resolve the `go mod tidy` dependency issues.