### PR TITLE
Add support for bundle to be defined based on a valid `org_id`

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -193,6 +193,36 @@ var _ = Describe("Identity Controller", func() {
 
 	})
 
+	Context("When a bundle is defined with use_valid_org_id", func() {
+		fakeResponse := SubscriptionsResponse{
+			StatusCode: 200,
+			Data:       FeatureStatus{},
+			CacheHit:   false,
+		}
+
+		Context("When the org_id is invalid", func() {
+			It("should not entitle bundles when a -1 org_id is supplied", func() {
+				rr, body, _ := testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "-1", true, DEFAULT_EMAIL, fakeGetFeatureStatus("-1", fakeResponse))
+				expectPass(rr.Result())
+				Expect(body["TestBundle7"].IsEntitled).To(Equal(false))
+			})
+
+			It("should not entitle bundles when a blank org_id is supplied", func() {
+				rr, body, _ := testRequest("GET", "/", DEFAULT_ACCOUNT_NUMBER, "", true, DEFAULT_EMAIL, fakeGetFeatureStatus("", fakeResponse))
+				expectPass(rr.Result())
+				Expect(body["TestBundle7"].IsEntitled).To(Equal(false))
+			})
+		})
+
+		Context("When the org_id is valid", func() {
+			It("should entitle bundles when a valid org_id is supplied", func() {
+				rr, body, _ := testRequest("GET", "/", "123456", DEFAULT_ORG_ID, true, DEFAULT_EMAIL, fakeGetFeatureStatus(DEFAULT_ORG_ID, fakeResponse))
+				expectPass(rr.Result())
+				Expect(body["TestBundle7"].IsEntitled).To(Equal(true))
+			})
+		})
+	})
+
 	Context("When a bundle uses only use_is_internal", func() {
 		fakeResponse := SubscriptionsResponse{
 			StatusCode: 200,

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -145,12 +145,14 @@ func Index() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		idObj := identity.Get(req.Context()).Identity
-		res := GetFeatureStatus(idObj.Internal.OrgID)
+		orgId := idObj.Internal.OrgID
+		res := GetFeatureStatus(orgId)
 		accNum := idObj.AccountNumber
 		isInternal := idObj.User.Internal
 		validEmailMatch, _ := regexp.MatchString(`^.*@redhat.com$`, idObj.User.Email)
 
 		validAccNum := !(accNum == "" || accNum == "-1")
+		validOrgId := !(orgId == "" || orgId == "-1")
 
 		if res.Error != nil {
 			errMsg := "Unexpected error while talking to Subs Service"
@@ -195,6 +197,10 @@ func Index() func(http.ResponseWriter, *http.Request) {
 
 			if b.UseValidAccNum {
 				entitle = validAccNum && entitle
+			}
+
+			if b.UseValidOrgId {
+				entitle = validOrgId && entitle
 			}
 
 			if b.UseIsInternal {

--- a/test_data/test_bundle.yml
+++ b/test_data/test_bundle.yml
@@ -24,3 +24,6 @@
     - SVC321
     - SVC654
     - MCT987
+
+- name: TestBundle7
+  use_valid_org_id: true

--- a/types/main.go
+++ b/types/main.go
@@ -42,6 +42,7 @@ type SubscriptionDetails struct {
 type Bundle struct {
 	Name           string   `yaml:"name"`
 	UseValidAccNum bool     `yaml:"use_valid_acc_num"`
+	UseValidOrgId  bool     `yaml:"use_valid_org_id"`
 	UseIsInternal  bool     `yaml:"use_is_internal"`
 	Skus           []string `yaml:"skus"`
 }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-18465

With the platform tenancy model moving from `account_number` to `org_id`, part
of this change will also include allowing requests into the platform for tenants
who do not have `account_numbers`. Today, everyone is required to have an `account_number`.

Once that happens, the business decision was made to allow access to current
`use_valid_acc_num` to not just tenants with an `account_number`, but _any_
tenant with an `org_id`, which effectively should be any authenticated request.
The onus of more granular control of these bundles will then fall to the UI/UX for
enforcing what users should see.

To support this in entitlements, we'll be adding the changes in this PR which will
add support for defining a bundle based on `use_valid_org_id` which will behave
the same as the check for `account_number`, only against `org_id`.

Once these code changes are deployed, we'll follow up with changes to our config [1]
to update the `use_valid_acc_num` bundles to `use_valid_org_id`.

[1] https://github.com/RedHatInsights/entitlements-config/

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
