### PR TITLE
Conditionally run `bundle-sync` on init

### DIFF
--- a/bundle_sync/main.go
+++ b/bundle_sync/main.go
@@ -106,6 +106,13 @@ func main() {
 	c := cfg.GetConfig()
 	client := getClient(c)
 	options := c.Options
+	runSync := options.GetBool(cfg.Keys.RunBundleSync)
+
+	if !runSync {
+		fmt.Println("Bundle sync disabled")
+		return
+	}
+
 	endpoints := strings.Split(c.Options.GetString(cfg.Keys.Features), ",")
 	for _, endpoint := range endpoints {
 		skus := make(map[string][]string)

--- a/config/main.go
+++ b/config/main.go
@@ -39,6 +39,7 @@ type EntitlementsConfigKeysType struct {
 	Features        string
 	FeaturesPath    string
 	SubAPIBasePath	string
+	RunBundleSync 	string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -58,6 +59,7 @@ var Keys = EntitlementsConfigKeysType{
 	CwSecret:        "CW_SECRET",
 	Features:        "FEATURES",
 	SubAPIBasePath:  "SUB_API_BASE_PATH",
+	RunBundleSync:   "RUN_BUNDLE_SYNC",
 }
 
 func getBaseFeaturesPath(options *viper.Viper) string {
@@ -131,6 +133,7 @@ func initialize() {
 	options.SetDefault(Keys.CwRegion, "us-east-1")
 	options.SetDefault(Keys.Features, "ansible,smart_management,rhods,rhoam,rhosak")
 	options.SetDefault(Keys.SubAPIBasePath, "/svcrest/subscription/v5/")
+	options.SetDefault(Keys.RunBundleSync, false)
 
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -59,6 +59,8 @@ objects:
                 value: /bundles/bundles.yml
               - name: ENT_CERTS_FROM_ENV
                 value: 'true'
+              - name: ENT_RUN_BUNDLE_SYNC
+                value: ${RUN_BUNDLE_SYNC}
             envFrom:
               - secretRef:
                   name: go-api-certs
@@ -179,3 +181,7 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
+- description: Flag to determine whether or not to sync bundles on init
+  name: RUN_BUNDLE_SYNC
+  required: false
+  value: false


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-19017

Since we have environments (FedRAMP/OCM/ephemeral) which share some of the stage
and prod IT endpoints, this means that there is the potential for these environments
to step on the stage/prod features by running the init container if the bundle
config is not in sync with what's in stage/prod.

This will allow us to conditionally, and explicitly enable running the bundle
sync in stage and prod only.

This will require an update to app-interface as well: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/38018