### PR TITLE
Entitle all when configured

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -42,6 +42,7 @@ type EntitlementsConfigKeysType struct {
 	SubAPIBasePath  string
 	CompAPIBasePath string
 	RunBundleSync   string
+	EntitleAll      string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -64,6 +65,7 @@ var Keys = EntitlementsConfigKeysType{
 	SubAPIBasePath:  "SUB_API_BASE_PATH",
 	CompAPIBasePath: "COMP_API_BASE_PATH",
 	RunBundleSync:   "RUN_BUNDLE_SYNC",
+	EntitleAll:      "ENTITLE_ALL",
 }
 
 func getBaseFeaturesPath(options *viper.Viper) string {

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -127,6 +127,10 @@ func failOnDependencyError(errMsg string, res types.SubscriptionsResponse, w htt
 	http.Error(w, string(errorResponsejson), 500)
 }
 
+func setBundlePayload(entitle bool, trial bool) types.EntitlementsSection {
+	return types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+}
+
 // Index the handler for GETs to /api/entitlements/v1/services/
 func Index() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
@@ -173,7 +177,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			trial := false
 			entitleAll := config.GetConfig().Options.GetBool(config.Keys.EntitleAll)
 			if entitleAll == true {
-				entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+				entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
 				continue
 			}
 
@@ -198,7 +202,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			if b.UseIsInternal {
 				entitle = validAccNum && isInternal && validEmailMatch
 			}
-			entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+			entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
 		}
 
 		obj, err := json.Marshal(entitlementsResponse)

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -171,6 +171,11 @@ func Index() func(http.ResponseWriter, *http.Request) {
 		for _, b := range bundleInfo {
 			entitle := true
 			trial := false
+			entitleAll := config.GetConfig().Options.GetBool(config.Keys.EntitleAll)
+			if entitleAll == true {
+				entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+				continue
+			}
 
 			if len(b.Skus) > 0 {
 				entitle = false


### PR DESCRIPTION
Conditionally allow for all bundles to be entitled, effectively mocking the response while keeping the integrity of the data structure and underlying logic to avoid duplication. To test locally, add `export ENT_ENTITLE_ALL=true` to your `./local/development.env.sh` file and observe that all bundles should return as entitled.

----

[Entitle all when ENT_ENTITLE_ALL is set to true](https://github.com/RedHatInsights/entitlements-api-go/commit/bb28aab5127bdf1f290c754e4486107acc97d113) 

When the environment variable `ENT_ENTITLE_ALL` is set to `true`, each bundle
will return as `is_entitled: true`, and `is_trial: false` (the defaults), without
checking the bundle definition or SKU list in subscriptions.

----

[Factor out reusable bundle payload setter](https://github.com/RedHatInsights/entitlements-api-go/commit/c39d0f61e743389a5f49e925fa6d26c85fe0665b) 

Whether or not we're short-circuiting the bundle checks, we need to set the payload
for each bundle. This factors out a reusable private function in the event it
changes down the road, allowing for one source of truth.

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
