### PR TITLE
Add new feature bundles

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -136,7 +136,7 @@ func initialize() {
 	options.SetDefault(Keys.CwLogGroup, "platform-dev")
 	options.SetDefault(Keys.CwLogStream, hostname)
 	options.SetDefault(Keys.CwRegion, "us-east-1")
-	options.SetDefault(Keys.Features, "ansible,smart_management,rhods,rhoam,rhosak")
+	options.SetDefault(Keys.Features, "ansible,smart_management,rhods,rhoam,rhosak,openshift,rhel")
 	options.SetDefault(Keys.SubAPIBasePath, "/svcrest/subscription/v5/")
 	options.SetDefault(Keys.CompAPIBasePath, "/v1/screening")
 	options.SetDefault(Keys.RunBundleSync, false)


### PR DESCRIPTION
The `openshift` and `rhel` bundles are now SKU-based. In order for the Features API to pick these new features, we need to have them run in the `bundle-sync`, which this config will allow for.
