### PR TITLE
Remove rhel bundle from default features in config/main.go

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -136,7 +136,7 @@ func initialize() {
 	options.SetDefault(Keys.CwLogGroup, "platform-dev")
 	options.SetDefault(Keys.CwLogStream, hostname)
 	options.SetDefault(Keys.CwRegion, "us-east-1")
-	options.SetDefault(Keys.Features, "ansible,smart_management,rhods,rhoam,rhosak,openshift,rhel")
+	options.SetDefault(Keys.Features, "ansible,smart_management,rhods,rhoam,rhosak,openshift")
 	options.SetDefault(Keys.SubAPIBasePath, "/svcrest/subscription/v5/")
 	options.SetDefault(Keys.CompAPIBasePath, "/v1/screening")
 	options.SetDefault(Keys.RunBundleSync, false)


### PR DESCRIPTION
Currently we don't need to post rhel's SKUs to subscription api. This returns state before this [PR](https://github.com/RedHatInsights/entitlements-api-go/pull/94) for rhel bundle.