### PR TITLE
Entitle all via config

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -42,6 +42,7 @@ type EntitlementsConfigKeysType struct {
 	SubAPIBasePath  string
 	CompAPIBasePath string
 	RunBundleSync   string
+	EntitleAll      string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -64,6 +65,7 @@ var Keys = EntitlementsConfigKeysType{
 	SubAPIBasePath:  "SUB_API_BASE_PATH",
 	CompAPIBasePath: "COMP_API_BASE_PATH",
 	RunBundleSync:   "RUN_BUNDLE_SYNC",
+	EntitleAll:      "ENTITLE_ALL",
 }
 
 func getBaseFeaturesPath(options *viper.Viper) string {
@@ -140,6 +142,7 @@ func initialize() {
 	options.SetDefault(Keys.SubAPIBasePath, "/svcrest/subscription/v5/")
 	options.SetDefault(Keys.CompAPIBasePath, "/v1/screening")
 	options.SetDefault(Keys.RunBundleSync, false)
+	options.SetDefault(Keys.EntitleAll, false)
 
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -136,6 +136,10 @@ func failOnDependencyError(errMsg string, res types.SubscriptionsResponse, w htt
 	http.Error(w, string(errorResponsejson), 500)
 }
 
+func setBundlePayload(entitle bool, trial bool) types.EntitlementsSection {
+	return types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+}
+
 // Index the handler for GETs to /api/entitlements/v1/services/
 func Index() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
@@ -183,7 +187,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			entitleAll := config.GetConfig().Options.GetString(config.Keys.EntitleAll)
 
 			if entitleAll == "true" {
-				entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+				entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
 				continue
 			}
 
@@ -208,7 +212,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 			if b.UseIsInternal {
 				entitle = validAccNum && isInternal && validEmailMatch
 			}
-			entitlementsResponse[b.Name] = types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
+			entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
 		}
 
 		obj, err := json.Marshal(entitlementsResponse)

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -69,6 +69,8 @@ objects:
               name: default-entitlements-config
         containers:
         - env:
+          - name: ENT_ENTITLE_ALL
+            value: ${ENTITLE_ALL}
           - name: ENT_CERTS_FROM_ENV
             value: 'true'
           - name: ENT_CA_PATH
@@ -188,5 +190,9 @@ parameters:
   required: true
 - description: Flag to determine whether or not to sync bundles on init
   name: RUN_BUNDLE_SYNC
+  required: false
+  value: 'false'
+- description: Flag to determine whether or not to entitle all by default and mock calls to IT
+  name: ENTITLE_ALL
   required: false
   value: 'false'


### PR DESCRIPTION
By setting `ENT_ENTITLE_ALL=true`, checks to external services to determine 
entitlements will be short-circuited and bundles will be entitled by default.

This will be helpful in installations where entitlements are still required to
keep an interface satisfied, but overall need to be permissive and not check against
actual tenancy entitlements.
