### PR TITLE
changed name of config file to be aligned with other steps in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run the Entitlements API locally, you will need an Enterprise Services cert w
 
 You'll need to make a config file specific to your machine.
 Create a local config directory: `mkdir -p ./local`
-Add a file that contains your local configuration options: `$EDITOR ./local/qa.conf.sh`
+Add a file that contains your local configuration options: `$EDITOR ./local/development.env.sh`
 The contents should look like this:
 
 ```sh


### PR DESCRIPTION
when I tried to run Entitlements service locally I found out there is an inconsistency of config file name