### PR TITLE
Add Clowdapp.yml file for Entitlements

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+
+	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 )
 
 var config *EntitlementsConfig
@@ -180,6 +182,17 @@ func initialize() {
 		Certs:   getCerts(options),
 		RootCAs: getRootCAs(options.GetString(Keys.CaPath)),
 		Options: options,
+	}
+
+	if clowder.IsClowderEnabled() {
+		cfg := clowder.LoadedConfig
+
+		// Cloudwatch
+		options.Set(Keys.CwLogGroup, cfg.Logging.Cloudwatch.LogGroup)
+		options.Set(Keys.CwLogStream, cfg.Logging.Cloudwatch.LogGroup)
+		options.Set(Keys.CwRegion, cfg.Logging.Cloudwatch.Region)
+		options.Set(Keys.CwKey, cfg.Logging.Cloudwatch.AccessKeyId)
+		options.Set(Keys.CwSecret, cfg.Logging.Cloudwatch.SecretAccessKey)
 	}
 }
 

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -80,26 +80,6 @@ objects:
           value: /apispec/api.spec.json
         - name: ENT_BUNDLE_INFO_YAML
           value: /bundles/bundles.yml
-        - name: ENT_CW_LOG_GROUP
-          valueFrom:
-            secretKeyRef:
-              key: log_group_name
-              name: cloudwatch
-        - name: ENT_CW_REGION
-          valueFrom:
-            secretKeyRef:
-              key: aws_region
-              name: cloudwatch
-        - name: ENT_CW_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: aws_secret_access_key
-              name: cloudwatch
-        - name: ENT_CW_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws_access_key_id
-              name: cloudwatch
         - name: GLITCHTIP_DSN
           valueFrom:
             secretKeyRef:

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -1,0 +1,163 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: entitlements-api-go
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: entitlements-api-go
+  spec:
+    optionalDependencies:
+    - rbac
+    envName: ${ENV_NAME}
+    deployments:
+    - name: service
+      webServices:
+        public:
+          enabled: True
+      minReplicas: ${{API_REPLICAS}}
+      podSpec:
+        initContainers:
+          - name: bundle-sync
+            image: quay.io/cloudservices/entitlements-api-go:${IMAGE_TAG}
+            command: ["/bundle-sync"]
+            env:
+              - name: ENT_SUBS_HOST
+                value: ${SUBS_HOST}
+              - name: ENT_BUNDLE_INFO_YAML
+                value: /bundles/bundles.yml
+              - name: ENT_CERTS_FROM_ENV
+                value: 'true'
+              - name: ENT_RUN_BUNDLE_SYNC
+                value: ${RUN_BUNDLE_SYNC}
+            envFrom:
+              - secretRef:
+                  name: go-api-certs
+            volumeMounts:
+            - mountPath: /bundles
+              name: default-entitlements-config
+            inheritEnv: true    
+        minReadySeconds: 15
+        progressDeadlineSeconds: 600
+        image: quay.io/cloudservices/entitlements-api-go:${IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 3000
+          initialDelaySeconds: 20
+          timeoutSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 60
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 250Mi
+      envFrom:
+        - secretRef:
+            name: go-api-certs
+      env:
+        - name: ENT_PORT
+          value: ${PORT}
+        - name: ENT_ENTITLE_ALL
+          value: ${ENTITLE_ALL}
+        - name: ENT_CERTS_FROM_ENV
+          value: 'true'
+        - name: ENT_CA_PATH
+          value: /resources/ca.crt
+        - name: ENT_SUBS_HOST
+          value: ${SUBS_HOST}
+        - name: ENT_COMPLIANCE_HOST
+          value: ${COMPLIANCE_HOST}
+        - name: ENT_OPENAPI_SPEC_PATH
+          value: /apispec/api.spec.json
+        - name: ENT_BUNDLE_INFO_YAML
+          value: /bundles/bundles.yml
+        - name: ENT_CW_LOG_GROUP
+          valueFrom:
+            secretKeyRef:
+              key: log_group_name
+              name: cloudwatch
+        - name: ENT_CW_REGION
+          valueFrom:
+            secretKeyRef:
+              key: aws_region
+              name: cloudwatch
+        - name: ENT_CW_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: aws_secret_access_key
+              name: cloudwatch
+        - name: ENT_CW_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws_access_key_id
+              name: cloudwatch
+        - name: GLITCHTIP_DSN
+          valueFrom:
+            secretKeyRef:
+              name: ${GLITCHTIP_SECRET}
+              key: dsn
+              optional: true
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/port: '3000'
+      prometheus.io/scrape: 'true'
+    labels:
+      app: entitlements-api-go
+    name: entitlements-api-go
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 8000
+    selector:
+      app: entitlements-service
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+
+parameters:
+- description: Port for listener
+  name: PORT
+  value: '8000'
+- description: Subscriptions Service API endpoint
+  name: SUBS_HOST
+  value: https://subscription.qa.api.redhat.com
+- description: Export Compliance Service API endpoint
+  name: COMPLIANCE_HOST
+  value: https://export-compliance.dev.api.redhat.com
+- description: Name of the entitlements-config config map
+  name: CONFIG_MAP_NAME
+  value: entitlements-config
+- description: The number of replicas to use in the deployment
+  name: REPLICAS
+  value: '1'
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Flag to determine whether or not to sync bundles on init
+  name: RUN_BUNDLE_SYNC
+  required: false
+  value: 'false'
+- description: Flag to determine whether or not to entitle all by default and mock calls to IT
+  name: ENTITLE_ALL
+  required: false
+  value: 'false'
+- description: The name of the Glitchtip secret
+  name: GLITCHTIP_SECRET
+  required: false
+  value: 'entitlements-secret'

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -9,8 +9,6 @@ objects:
   metadata:
     name: entitlements-api-go
   spec:
-    optionalDependencies:
-    - rbac
     envName: ${ENV_NAME}
     deployments:
     - name: service

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/redhatinsights/app-common-go v1.6.6 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+github.com/redhatinsights/app-common-go v1.6.6 h1:daOwCpGtW6IxGd9iO6TY3yoaV/HaHKjo/j/05dV0hHM=
+github.com/redhatinsights/app-common-go v1.6.6/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa h1:noqA6UChsLTI+OQzWzzc+ASnAKb3RYlUfMHiJmY2rjM=
 github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
This PR adds a clowdapp.yml file for the Clowderization of Entitlements in the FedRAMP environment, this can also be used in Commercial once the time comes to switch it over.

Additionally the Entitlements service needs to communicate with Cloudwatch, so I added the app-common-go library and made the corresponding changes in the config file for the entitlements service.

NOTE: This change creates a Service that exists on port 3000 but declares it's target port on 8000 meaning that the Gateway doesn't need to change any of its code to send requests to the clowderized Entitlements.

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
