### PR TITLE
added feature flag to expose seat manager apis, and features env

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -24,71 +24,73 @@ type EntitlementsConfig struct {
 
 // EntitlementsConfigKeysType is the definition of the struct hat houses all the env variables key names
 type EntitlementsConfigKeysType struct {
-	Key             string
-	Cert            string
-	Port            string
-	LogLevel        string
-	CertsFromEnv    string
-	SubsHost        string
-	ComplianceHost  string
-	CaPath          string
-	OpenAPISpecPath string
-	BundleInfoYaml  string
-	CwLogGroup      string
-	CwLogStream     string
-	CwRegion        string
-	CwKey           string
-	CwSecret        string
-	Features        string
-	FeaturesPath    string
-	SubAPIBasePath  string
-	CompAPIBasePath string
-	RunBundleSync   string
-	EntitleAll      string
-	AMSHost         string
-	ClientID        string
-	ClientSecret    string
-	TokenURL        string
-	Debug           string
-	BOPClientID     string
-	BOPToken        string
-	BOPURL          string
-	BOPEnv          string
-	BOPMockOrgId    string
+	Key                string
+	Cert               string
+	Port               string
+	LogLevel           string
+	CertsFromEnv       string
+	SubsHost           string
+	ComplianceHost     string
+	CaPath             string
+	OpenAPISpecPath    string
+	BundleInfoYaml     string
+	CwLogGroup         string
+	CwLogStream        string
+	CwRegion           string
+	CwKey              string
+	CwSecret           string
+	Features           string
+	FeaturesPath       string
+	SubAPIBasePath     string
+	CompAPIBasePath    string
+	RunBundleSync      string
+	EntitleAll         string
+	AMSHost            string
+	ClientID           string
+	ClientSecret       string
+	TokenURL           string
+	Debug              string
+	BOPClientID        string
+	BOPToken           string
+	BOPURL             string
+	BOPEnv             string
+	BOPMockOrgId       string
+	DisableSeatManager string
 }
 
 // Keys is a struct that houses all the env variables key names
 var Keys = EntitlementsConfigKeysType{
-	Key:             "KEY",
-	Cert:            "CERT",
-	Port:            "PORT",
-	LogLevel:        "LOG_LEVEL",
-	CertsFromEnv:    "CERTS_FROM_ENV",
-	SubsHost:        "SUBS_HOST",
-	ComplianceHost:  "COMPLIANCE_HOST",
-	CaPath:          "CA_PATH",
-	OpenAPISpecPath: "OPENAPI_SPEC_PATH",
-	BundleInfoYaml:  "BUNDLE_INFO_YAML",
-	CwLogGroup:      "CW_LOG_GROUP",
-	CwLogStream:     "CW_LOG_STEAM",
-	CwRegion:        "CW_REGION",
-	CwKey:           "CW_KEY",
-	CwSecret:        "CW_SECRET",
-	Features:        "FEATURES",
-	SubAPIBasePath:  "SUB_API_BASE_PATH",
-	CompAPIBasePath: "COMP_API_BASE_PATH",
-	RunBundleSync:   "RUN_BUNDLE_SYNC",
-	EntitleAll:      "ENTITLE_ALL",
-	AMSHost:         "AMS_HOST",
-	ClientID:        "OIDC_CLIENT_ID",
-	ClientSecret:    "OIDC_CLIENT_SECRET",
-	TokenURL:        "OAUTH_TOKEN_URL",
-	BOPClientID:     "BOP_CLIENT_ID",
-	BOPToken:        "BOP_TOKEN",
-	BOPURL:          "BOP_URL",
-	BOPMockOrgId:    "BOP_MOCK_ORG_ID",
-	BOPEnv:          "BOP_ENV",
-	Debug:           "DEBUG",
+	Key:                "KEY",
+	Cert:               "CERT",
+	Port:               "PORT",
+	LogLevel:           "LOG_LEVEL",
+	CertsFromEnv:       "CERTS_FROM_ENV",
+	SubsHost:           "SUBS_HOST",
+	ComplianceHost:     "COMPLIANCE_HOST",
+	CaPath:             "CA_PATH",
+	OpenAPISpecPath:    "OPENAPI_SPEC_PATH",
+	BundleInfoYaml:     "BUNDLE_INFO_YAML",
+	CwLogGroup:         "CW_LOG_GROUP",
+	CwLogStream:        "CW_LOG_STEAM",
+	CwRegion:           "CW_REGION",
+	CwKey:              "CW_KEY",
+	CwSecret:           "CW_SECRET",
+	Features:           "FEATURES",
+	SubAPIBasePath:     "SUB_API_BASE_PATH",
+	CompAPIBasePath:    "COMP_API_BASE_PATH",
+	RunBundleSync:      "RUN_BUNDLE_SYNC",
+	EntitleAll:         "ENTITLE_ALL",
+	AMSHost:            "AMS_HOST",
+	ClientID:           "OIDC_CLIENT_ID",
+	ClientSecret:       "OIDC_CLIENT_SECRET",
+	TokenURL:           "OAUTH_TOKEN_URL",
+	BOPClientID:        "BOP_CLIENT_ID",
+	BOPToken:           "BOP_TOKEN",
+	BOPURL:             "BOP_URL",
+	BOPMockOrgId:       "BOP_MOCK_ORG_ID",
+	BOPEnv:             "BOP_ENV",
+	Debug:              "DEBUG",
+	DisableSeatManager: "DISABLE_SEAT_MANAGER",
 }
 
 func getBaseFeaturesPath(options *viper.Viper) string {
@@ -173,6 +175,7 @@ func initialize() {
 	options.SetDefault(Keys.BOPMockOrgId, "4384938490324")
 	options.SetDefault(Keys.BOPEnv, "stage")
 	options.SetDefault(Keys.Debug, false)
+	options.SetDefault(Keys.DisableSeatManager, false)
 
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -101,6 +101,10 @@ objects:
             value: /apispec/api.spec.json
           - name: ENT_BUNDLE_INFO_YAML
             value: /bundles/bundles.yml
+          - name: ENT_FEATURES
+            value: ${FEATURES}
+          - name: ENT_DISABLE_SEAT_MANAGER
+            value: ${DISABLE_SEAT_MANAGER}
           - name: GLITCHTIP_DSN
             valueFrom:
               secretKeyRef:
@@ -209,6 +213,12 @@ parameters:
   name: GLITCHTIP_SECRET
   required: false
   value: 'entitlements-secret'
+- description: List of feature bundles to onboard during bundle sync
+  name: FEATURES
+  required: false
+- description: Flag to disable seat manager by not exposing any of the apis related to the feature
+  name: DISABLE_SEAT_MANAGER
+  required: false
 - description: ClowdEnv Name
   name: ENV_NAME
   required: true

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -91,6 +91,10 @@ objects:
             value: ${BOP_URL}
           - name: ENT_BOP_ENV
             value: ${BOP_ENV}
+          - name: ENT_FEATURES
+            value: ${FEATURES}
+          - name: ENT_DISABLE_SEAT_MANAGER
+            value: ${DISABLE_SEAT_MANAGER}
           - name: ENT_CW_LOG_GROUP
             valueFrom:
               secretKeyRef:
@@ -242,3 +246,9 @@ parameters:
   name: GLITCHTIP_SECRET
   required: false
   value: 'entitlements-secret'
+- description: List of feature bundles to onboard during bundle sync
+  name: FEATURES
+  required: false
+- description: Flag to disable seat manager by not exposing any of the apis related to the feature
+  name: DISABLE_SEAT_MANAGER
+  required: false


### PR DESCRIPTION
Added 2 params to our deployment templates: one to seat the FEATURES env var, and one to set a new feature flag to disable/not expose the seat manager apis. We want to do a prod deploy but not expose the seat manager stuff yet

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
