### PR TITLE
[RHCLOUD-19521] add exception for DVO min three replicas for entitlements Deployment

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -9,6 +9,8 @@ objects:
     labels:
       app: entitlements-api-go
     name: entitlements-api-go
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "for entitlements we dont need 3 replicas"
   spec:
     minReadySeconds: 15
     progressDeadlineSeconds: 600


### PR DESCRIPTION
* add exception for skipping the DVO min 3 replicas check
* right now the entitlements uses caching in memory per pod, so if we increase min replicas to 3, then there will be more cache misses and that is why we want to use this exception and solve FIRING tickets we have on board ... in the future we plan to use elasticache so then we can remove this label and bump to 3 replicas

JIRA: 
* [RHCLOUD-19521](https://issues.redhat.com/browse/RHCLOUD-19521) [FIRING:1] deployment_validation_operator_minimum_three_replicas entitlements crcs02ue1 deployment-validation-operator-metrics deployment-validation-operator
* [RHCLOUD-19585](https://issues.redhat.com/browse/RHCLOUD-19585) [FIRING:1] deployment_validation_operator_minimum_three_replicas entitlements crcp01ue1 deployment-validation-operator-metrics deployment-validation-operator