### PR TITLE
set cpu and memory limits and request for initContainer in deploy.yml

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -52,6 +52,13 @@ objects:
           - name: bundle-sync
             image: quay.io/cloudservices/entitlements-api-go:${IMAGE_TAG}
             command: ["/bundle-sync"]
+            resources:
+              limits:
+                cpu: 200m
+                memory: 200Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
             env:
               - name: ENT_SUBS_HOST
                 value: ${SUBS_HOST}


### PR DESCRIPTION
to solve 4 FIRIGN tickets we need to set cpu and memory limits and request for initContainer
(discussed and recommended from AppSRE team)

this should solve these tickets:
- [RHCLOUD-24821](https://issues.redhat.com/browse/RHCLOUD-24821) [FIRING:1] unset_memory entitlements stage
- [RHCLOUD-24817](https://issues.redhat.com/browse/RHCLOUD-24817) [FIRING:1] unset_memory entitlements prod
- [RHCLOUD-24819](https://issues.redhat.com/browse/RHCLOUD-24819) [FIRING:1] unset_cpu entitlements stage
- [RHCLOUD-24818](https://issues.redhat.com/browse/RHCLOUD-24818) [FIRING:1] unset_cpu entitlements prod