### PR TITLE
make subscriptions cache settings configurable

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -56,6 +56,9 @@ type EntitlementsConfigKeysType struct {
 	BOPEnv             string
 	BOPMockOrgId       string
 	DisableSeatManager string
+	SubsCacheDuration  string
+	SubsCacheMaxSize   string
+	SubsCacheItemPrune string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -91,6 +94,9 @@ var Keys = EntitlementsConfigKeysType{
 	BOPEnv:             "BOP_ENV",
 	Debug:              "DEBUG",
 	DisableSeatManager: "DISABLE_SEAT_MANAGER",
+	SubsCacheDuration:  "SUBS_CACHE_DURATION_SECONDS",
+	SubsCacheMaxSize:   "SUBS_CACHE_MAX_SIZE",
+	SubsCacheItemPrune: "SUBS_CACHE_ITEM_PRUNE",
 }
 
 func getBaseFeaturesPath(options *viper.Viper) string {
@@ -176,6 +182,9 @@ func initialize() {
 	options.SetDefault(Keys.BOPEnv, "stage")
 	options.SetDefault(Keys.Debug, false)
 	options.SetDefault(Keys.DisableSeatManager, false)
+	options.SetDefault(Keys.SubsCacheDuration, 1800) // seconds
+	options.SetDefault(Keys.SubsCacheMaxSize, 500)
+	options.SetDefault(Keys.SubsCacheItemPrune, 50)
 
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -105,6 +105,12 @@ objects:
             value: ${FEATURES}
           - name: ENT_DISABLE_SEAT_MANAGER
             value: ${DISABLE_SEAT_MANAGER}
+          - name: ENT_SUBS_CACHE_DURATION_SECONDS
+            value: ${SUBS_CACHE_DURATION}
+          - name: ENT_SUBS_CACHE_MAX_SIZE
+            value: ${SUBS_CACHE_MAX_SIZE}
+          - name: ENT_SUBS_CACHE_ITEM_PRUNE
+            value: ${SUBS_CACHE_ITEM_PRUNE}
           - name: GLITCHTIP_DSN
             valueFrom:
               secretKeyRef:
@@ -218,6 +224,15 @@ parameters:
   required: false
 - description: Flag to disable seat manager by not exposing any of the apis related to the feature
   name: DISABLE_SEAT_MANAGER
+  required: false
+- description: Duration, in seconds, for items in the subs cache before they are expired
+  name: SUBS_CACHE_DURATION
+  required: false
+- description: Max size of the subs cache
+  name: SUBS_CACHE_MAX_SIZE
+  required: false
+- description: Items to prune for the subs cache (when memory is low)
+  name: SUBS_CACHE_ITEM_PRUNE
   required: false
 - description: ClowdEnv Name
   name: ENV_NAME

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -104,6 +104,12 @@ objects:
             value: ${FEATURES}
           - name: ENT_DISABLE_SEAT_MANAGER
             value: ${DISABLE_SEAT_MANAGER}
+          - name: ENT_SUBS_CACHE_DURATION_SECONDS
+            value: ${SUBS_CACHE_DURATION}
+          - name: ENT_SUBS_CACHE_MAX_SIZE
+            value: ${SUBS_CACHE_MAX_SIZE}
+          - name: ENT_SUBS_CACHE_ITEM_PRUNE
+            value: ${SUBS_CACHE_ITEM_PRUNE}
           - name: ENT_CW_LOG_GROUP
             valueFrom:
               secretKeyRef:
@@ -260,4 +266,13 @@ parameters:
   required: false
 - description: Flag to disable seat manager by not exposing any of the apis related to the feature
   name: DISABLE_SEAT_MANAGER
+  required: false
+- description: Duration, in seconds, for items in the subs cache before they are expired
+  name: SUBS_CACHE_DURATION
+  required: false
+- description: Max size of the subs cache
+  name: SUBS_CACHE_MAX_SIZE
+  required: false
+- description: Items to prune for the subs cache (when memory is low)
+  name: SUBS_CACHE_ITEM_PRUNE
   required: false


### PR DESCRIPTION
Extract subscriptions cache settings to env variables so we can configure them per environment.

I chose to expose seconds as the unit of duration cuz I figure thats as much granularity as we would probably ever want. I can bump to minutes if we think that is more readable or to whatever anyone thinks is best

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
