### PR TITLE
Update Dockerfile to use registry.access.redhat.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ USER 0
 RUN make
 
 # Using ubi8-minimal due to its smaller footprint
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /
 


### PR DESCRIPTION
## Overview

This PR is to change the `Red Hat Container Registry` used in the Dockefile to pull `UBI8-minimal` 



Registry | Content | Supports Unauthenticated Access | Supports Red Hat login | Supports Registry Tokens
-- | -- | -- | -- | --
registry.access.redhat.com | Red Hat products | Yes | No | No
registry.redhat.io | Red Hat products | No | Yes | Yes



----

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 
