### PR TITLE
RHCLOUD-27585: add first and last name to get seats response

### DIFF
--- a/ams/test_client.go
+++ b/ams/test_client.go
@@ -56,7 +56,7 @@ var MockGetSubscriptions = func(organizationId string, size, page int) (*v1.Subs
     lst, err := v1.NewSubscriptionList().
         Items(
             v1.NewSubscription().
-                Creator(v1.NewAccount().Username("testuser")).
+                Creator(v1.NewAccount().Username("testuser").FirstName("test").LastName("user")).
                 Plan(v1.NewPlan().Type("AnsibleWisdom").Name("AnsibleWisdom")).
                 Status("Active"),
         ).Build()

--- a/apispec/api.spec.json
+++ b/apispec/api.spec.json
@@ -448,6 +448,12 @@
                     },
                     "status": {
                         "type": "string"
+                    },
+                    "first_name": {
+                        "type": "string"
+                    },
+                    "last_name": {
+                        "type": "string"
                     }
                 }
             },


### PR DESCRIPTION
# Summary
Add first name and last name of the associated account to each seat in the `GET api/entitlements/v1/seats` endpoint

## Tickets
https://issues.redhat.com/browse/RHCLOUD-27585

## Testing
* Added unit tests to cover change, run with `make test`
* TODO: test locally against stage ams

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
