### PR TITLE
Set current bundles

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -241,5 +241,5 @@ parameters:
   required: true
 - description: Application allows list for new bundles with skus to update the feature in the IT features API
   name: BUNDLES_SKUS_ALLOW_LIST
-  value: ansible,smart_management_rods,rhoam,rhosak,openshift,rhel
+  value: ansible,smart_management,rhods,rhoam,rhosak,openshift,acs
   required: false

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -257,7 +257,7 @@ parameters:
   value: 'false'
 - description: Application allow list for new bundles with skus to update the feature in the IT features API
   name: BUNDLES_SKUS_ALLOW_LIST
-  value: ansible,smart_management_rods,rhoam,rhosak,openshift,rhel
+  value: ansible,smart_management,rhods,rhoam,rhosak,openshift,acs
 - description: Flag to determine whether or not to entitle all by default and mock calls to IT
   name: ENTITLE_ALL
   required: false


### PR DESCRIPTION
This set bundles according to current state:

1. Typo: `smart_management_rods`  -> `smart_management,rhods`
2. Remove `rhel` https://github.com/RedHatInsights/entitlements-api-go/pull/96
3. Add `acs` https://github.com/RedHatInsights/entitlements-api-go/pull/123


