### PR TITLE
add GO param to makefile to point to desired go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+# lazy set if absent - if GO is set in env or as parameter it will override this default
+# https://www.gnu.org/software/make/manual/html_node/Conditional-Assignment.html
+GO ?= go
 gen_files = api/server.gen.go api/types.gen.go
-GO = go
 
 all: generate build
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 gen_files = api/server.gen.go api/types.gen.go
+GO = go
 
 all: generate build
 build:
-	go build -o entitlements-api-go main.go
-	go build -o ./bundle-sync bundle_sync/main.go
+	$(GO) build -o entitlements-api-go main.go
+	$(GO) build -o ./bundle-sync bundle_sync/main.go
 clean:
 	find . -name "*.gen.go" | xargs rm
-	go clean -cache
+	$(GO) clean -cache
 	rm entitlements-api-go
 
 $(gen_files): apispec/api.spec.json
-	go generate ./...
+	$(GO) generate ./...
 
 generate: $(gen_files)
 
@@ -20,12 +21,12 @@ exe: all
 	./entitlements-api-go
 debug-run: generate
 	ENT_DEBUG=1 \
-	go run main.go
+	$(GO) run main.go
 run: generate
-	go run main.go
+	$(GO) run main.go
 test: generate
-	go test -v ./...
+	$(GO) test -v ./...
 test-all: generate
-	go test -v --race --coverprofile=coverage.txt --covermode=atomic ./...
+	$(GO) test -v --race --coverprofile=coverage.txt --covermode=atomic ./...
 bench: generate
-	go test -bench=. ./...
+	$(GO) test -bench=. ./...

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Build the project and generate the openapi types and stubs:
 make
 ```
 
+If your local version differs from what entitlements is using, you can download the desired version of go here: [go.dev/doc/manage-install](https://go.dev/doc/manage-install), and then pass the path to the go binary to all make commands like so:
+```sh
+make GO=~/go/bin/go1.19
+```
+
 ## Certificates and Configuration
 
 ### Getting an Enterprise Cert


### PR DESCRIPTION
Add a `GO` param to makefile so you can specify the desired go binary in make commands like so:
```
make GO=~/go/bin/go1.19
```