### PR TITLE
Force cache clear

### DIFF
--- a/apispec/api.spec.json
+++ b/apispec/api.spec.json
@@ -75,6 +75,18 @@
                         },
                         "explode": false,
                         "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "trial_activated",
+                        "required": false,
+                        "description": "Flag to indicate if a subscription trial has been activated. If true it forces a user's subscriptions to be served live.",
+                        "schema":{
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "explode": false,
+                        "style": "form"
                     }
                 ],
                 "responses": {

--- a/controllers/compliance_test.go
+++ b/controllers/compliance_test.go
@@ -3,22 +3,22 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/RedHatInsights/entitlements-api-go/config"
 	"github.com/RedHatInsights/entitlements-api-go/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 )
 
 var defaultEmail = "test@redhat.com"
 
 func readResponse(respBody io.ReadCloser) []byte {
-	out, err := ioutil.ReadAll(respBody)
-	Expect(err).To(BeNil(), "ioutil.ReadAll error was not nil")
+	out, err := io.ReadAll(respBody)
+	Expect(err).To(BeNil(), "io.ReadAll error was not nil")
 	respBody.Close()
 
 	return out
@@ -38,7 +38,7 @@ func getContextWithIdentity(username string) context.Context {
 	return ctx
 }
 
-var _ = Describe("", func() {
+var _ = Describe("Compliance Controller", func() {
 	Context("When username is empty", func() {
 		It("should return an error and status 400", func() {
 			// given

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -44,7 +44,7 @@ func testRequest(method string, path string, accnum string, orgid string, isinte
 
 	GetFeatureStatus = fakeCaller
 
-	Index()(rr, req)
+	Services()(rr, req)
 
 	out, err := io.ReadAll(rr.Result().Body)
 	Expect(err).To(BeNil(), "io.ReadAll error was not nil")

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -25,7 +24,7 @@ type statusInfo struct {
 
 func buildStatus() statusInfo {
 	specFilePath := config.GetConfig().Options.GetString(config.Keys.OpenAPISpecPath)
-	specFile, err := ioutil.ReadFile(specFilePath)
+	specFile, err := os.ReadFile(specFilePath)
 
 	apiVersion := ""
 

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -3,8 +3,9 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +65,7 @@ type GetFeatureStatusParams struct {
 
 // SetBundleInfo sets the bundle information fetched from the YAML
 func SetBundleInfo(yamlFilePath string) error {
-	bundlesYaml, err := ioutil.ReadFile(yamlFilePath)
+	bundlesYaml, err := os.ReadFile(yamlFilePath)
 
 	if err != nil {
 		sentry.CaptureException(err)
@@ -118,7 +119,7 @@ var GetFeatureStatus = func(params GetFeatureStatusParams) types.SubscriptionsRe
 
 	if resp.StatusCode != 200 {
 		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return types.SubscriptionsResponse{
 			StatusCode: resp.StatusCode,
 			Body:       string(body),
@@ -131,7 +132,7 @@ var GetFeatureStatus = func(params GetFeatureStatusParams) types.SubscriptionsRe
 	defer resp.Body.Close()
 
 	// Unmarshaling response from Feature service
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	var FeatureStatus types.FeatureStatus
 	json.Unmarshal(body, &FeatureStatus)
 

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -60,7 +60,7 @@ const (
 
 type GetFeatureStatusParams struct {
 	OrgId 			string
-	ForceLiveStatus	bool
+	ForceFreshData	bool
 }
 
 // SetBundleInfo sets the bundle information fetched from the YAML
@@ -165,8 +165,8 @@ func setBundlePayload(entitle bool, trial bool) types.EntitlementsSection {
 	return types.EntitlementsSection{IsEntitled: entitle, IsTrial: trial}
 }
 
-// Index the handler for GETs to /api/entitlements/v1/services/
-func Index() func(http.ResponseWriter, *http.Request) {
+// Services the handler for GETs to /api/entitlements/v1/services/
+func Services() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		idObj := identity.Get(req.Context()).Identity
@@ -180,7 +180,7 @@ func Index() func(http.ResponseWriter, *http.Request) {
 		subscriptions := GetFeatureStatus(
 			GetFeatureStatusParams{
 				OrgId: orgId, 
-				ForceLiveStatus: queryParams.TrialActivated,
+				ForceFreshData: queryParams.TrialActivated,
 			},
 		)
 		

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -59,7 +59,7 @@ const (
 )
 
 type GetFeatureStatusParams struct {
-	OrgId 			string
+	OrgId 		string
 	ForceFreshData	bool
 }
 

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -87,7 +87,7 @@ var GetFeatureStatus = func(params GetFeatureStatusParams) types.SubscriptionsRe
 	item := cache.Get(orgID)
 	entitleAll := configOptions.GetString(config.Keys.EntitleAll)
 
-	if item != nil && !item.Expired() {
+	if item != nil && !item.Expired() && !params.ForceFreshData{
 		return types.SubscriptionsResponse{
 			StatusCode: 200,
 			Data:       item.Value().(types.FeatureStatus),
@@ -299,11 +299,16 @@ func filtersFromParams(req *http.Request, filterName string) []string {
 
 func boolFromParams(req *http.Request, paramName string) bool {
 	strParam := req.URL.Query().Get(paramName)
-	b, err := strconv.ParseBool(strParam)
+
+	if strParam == "" {
+		return false
+	}
+
+	param, err := strconv.ParseBool(strParam)
 
 	if err != nil {
 		return false
 	}
 
-	return b
+	return param
 }

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -73,7 +73,7 @@ func expectPass(res *http.Response) {
 	Expect(res.Header.Get("Content-Type")).To(Equal("application/json"))
 }
 
-var _ = Describe("Identity Controller", func() {
+var _ = Describe("Services Controller", func() {
 
 	BeforeEach(func() {
 		bundleInfo = []Bundle{}

--- a/server/routes.go
+++ b/server/routes.go
@@ -61,7 +61,7 @@ func DoRoutes() chi.Router {
 	r.Route("/api/entitlements/v1", func(r chi.Router) {
 		r.With(identity.EnforceIdentity).Route("/", controllers.LubDub)
 		r.Route("/openapi.json", apispec.OpenAPISpec)
-		r.With(identity.EnforceIdentity).Get("/services", controllers.Index())
+		r.With(identity.EnforceIdentity).Get("/services", controllers.Services())
 		r.With(identity.EnforceIdentity).Get("/compliance", controllers.Compliance())
 	})
 

--- a/types/main.go
+++ b/types/main.go
@@ -16,12 +16,6 @@ type SubscriptionsResponse struct {
 	CacheHit   bool
 }
 
-// Entries is a struct that is used to unmarshal the entries field that comes back from the
-// response of the Subscription Service
-type Entries struct {
-	Value string
-}
-
 type Feature struct {
 	Name     string `json:"name"`
 	IsEval   bool   `json:"isEval"`
@@ -30,12 +24,6 @@ type Feature struct {
 
 type FeatureStatus struct {
 	Features []Feature `json:"features"`
-}
-
-// SubscriptionDetails is a struct that is used to unmarshal the data that comes back in the Body
-// of the response of Subscriptions Service
-type SubscriptionDetails struct {
-	Entries []Entries
 }
 
 // Bundle is a struct that is used to unmarshal the bundle info from bundles.yml


### PR DESCRIPTION
## Summary 
* add a `trial_activated` query param to `GET /services`
* when `GET /services?trial_activated=true`, force entitlements to retrieve live data from IT subscriptions service, even if cache is hot
* some small tidying like renaming files/variables, removing usage of `ioutil`, adding some context to existing tests, removing unused structs

### Tickets
* https://issues.redhat.com/browse/RHCLOUD-28782

### Testing
* setup your local environment in `local/development.env.sh` like so:
```
export GO=~/go/bin/go1.19 # or where ever go1.19 is located. ignore if this if default go on your system is 1.19. theres a problem with 1.21 that isnt compatible with entitlements
export ENT_CA_PATH=<path to entitlements-api-go>/resources/ca.crt
export ENT_SUBS_HOST=https://subscription.stage.api.redhat.com
```
* start the service with `make exe`
* keep the logs for the service open, and then hit `http://localhost:3000/api/entitlements/v1/services`
* check the logs, and you should see a log like this:
```
{
  "cache_hit": false,
  "caller": "github.com/RedHatInsights/entitlements-api-go/controllers.Services.func1",
  "file": "/home/danielagbay/workspace/consoledot/entitlements-api-go/controllers/subscriptions.go:206",
  "logLevel": "info",
  "msg": "subs call complete",
  "subs_call_duration": 0.191131474,
  "ts": "2023-11-09T17:58:20-06:00"
}

```
* the `cache_hit: false` is whats important. so now that our cache is primed, send the same request and you see the same log but this time with `cache_hit: true` meaning data was served from cache
* keep the service running, and now hit `http://localhost:3000/api/entitlements/v1/services?trial_activated=true`
* you should now see the log from above with `cache_hit: false` every time you send the request, meaning data is not served from cache, as expected
