### PR TITLE
add a timeout to the http client we use to call IT services

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -60,6 +60,7 @@ type EntitlementsConfigKeysType struct {
 	SubsCacheMaxSize   string
 	SubsCacheItemPrune string
 	AMSAcctMgmt11Msg   string
+	ITServicesTimeoutSeconds  string
 }
 
 // Keys is a struct that houses all the env variables key names
@@ -99,6 +100,7 @@ var Keys = EntitlementsConfigKeysType{
 	SubsCacheMaxSize:   "SUBS_CACHE_MAX_SIZE",
 	SubsCacheItemPrune: "SUBS_CACHE_ITEM_PRUNE",
 	AMSAcctMgmt11Msg:	"AMS_ACCT_MGMT_11_ERR_MSG",
+	ITServicesTimeoutSeconds:  "IT_SERVICES_TIMEOUT_SECONDS",
 }
 
 func getRootCAs(localCertFile string) *x509.CertPool {
@@ -190,6 +192,7 @@ func initialize() {
 	options.SetDefault(Keys.SubsCacheMaxSize, 500)
 	options.SetDefault(Keys.SubsCacheItemPrune, 50)
 	options.SetDefault(Keys.AMSAcctMgmt11Msg, "Please have this user log into \"https://console.redhat.com/openshift\" to grant their account the required permissions, or try again later.")
+	options.SetDefault(Keys.ITServicesTimeoutSeconds, 10)
 
 	options.SetEnvPrefix("ENT")
 	options.AutomaticEnv()

--- a/controllers/client.go
+++ b/controllers/client.go
@@ -2,16 +2,23 @@ package controllers
 
 import (
 	"crypto/tls"
-	"github.com/RedHatInsights/entitlements-api-go/config"
 	"net/http"
+	"time"
+
+	"github.com/RedHatInsights/entitlements-api-go/config"
 )
 
 func getClient() *http.Client {
+	cfg := config.GetConfig()
+	options := cfg.Options
+	timeout := options.GetInt(config.Keys.ITServicesTimeoutSeconds)
+
 	// Create a HTTPS client that uses the supplied pub/priv mutual TLS certs
 	return &http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:      config.GetConfig().RootCAs,
+				RootCAs:      cfg.RootCAs,
 				Certificates: []tls.Certificate{*config.GetConfig().Certs},
 			},
 		},

--- a/controllers/client.go
+++ b/controllers/client.go
@@ -10,8 +10,7 @@ import (
 
 func getClient() *http.Client {
 	cfg := config.GetConfig()
-	options := cfg.Options
-	timeout := options.GetInt(config.Keys.ITServicesTimeoutSeconds)
+	timeout := cfg.Options.GetInt(config.Keys.ITServicesTimeoutSeconds)
 
 	// Create a HTTPS client that uses the supplied pub/priv mutual TLS certs
 	return &http.Client{

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -113,6 +113,8 @@ objects:
             value: ${SUBS_CACHE_ITEM_PRUNE}
           - name: ENT_AMS_ACCT_MGMT_11_ERR_MSG
             value: ${AMS_ACCT_MGMT_11_ERR_MSG}
+          - name: ENT_IT_SERVICES_TIMEOUT_SECONDS
+            value: ${IT_SERVICES_TIMEOUT_SECONDS}
           - name: GLITCHTIP_DSN
             valueFrom:
               secretKeyRef:
@@ -233,4 +235,7 @@ parameters:
   required: true
 - description: Error message to display for the ACCT-MGMT-11 error message
   name: AMS_ACCT_MGMT_11_ERR_MSG
+  required: false
+- description: Timeout for outbound requests to IT services, in seconds
+  name: IT_SERVICES_TIMEOUT_SECONDS
   required: false


### PR DESCRIPTION
## Summary
add a timeout to our http calls to IT subs and compliance services

### Why
right now we do not set an explicit timeout, and the go http client defaults to no timeout if none provided

we do not want to give our http calls the opportunity to hang indefinitely, so we set the timeout with a default of 10s
