### PR TITLE
memoize http clients

### DIFF
--- a/controllers/client.go
+++ b/controllers/client.go
@@ -8,12 +8,18 @@ import (
 	"github.com/RedHatInsights/entitlements-api-go/config"
 )
 
+var client *http.Client
+
 func getClient() *http.Client {
+	if client != nil {
+		return client
+	}
+
 	cfg := config.GetConfig()
 	timeout := cfg.Options.GetInt(config.Keys.ITServicesTimeoutSeconds)
 
 	// Create a HTTPS client that uses the supplied pub/priv mutual TLS certs
-	return &http.Client{
+	client = &http.Client{
 		Timeout: time.Duration(timeout) * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -22,4 +28,6 @@ func getClient() *http.Client {
 			},
 		},
 	}
+	
+	return client
 }

--- a/controllers/client_test.go
+++ b/controllers/client_test.go
@@ -1,0 +1,19 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("http client", func() {
+	It("should not create a new client every call", func(){
+		// given
+		client1 := getClient()
+
+		// when
+		client2 := getClient()
+
+		// then
+		Expect(client1).To(BeIdenticalTo(client2))
+	})
+})

--- a/controllers/compliance_test.go
+++ b/controllers/compliance_test.go
@@ -152,7 +152,6 @@ var _ = Describe("Compliance Controller", func() {
 			rr := httptest.NewRecorder()
 
 			cfg := config.GetConfig().Options
-			cfg.Set(config.Keys.ITServicesTimeoutSeconds, 2)
 			wait := cfg.GetInt(config.Keys.ITServicesTimeoutSeconds) + 1
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"testing"
 
+	"github.com/RedHatInsights/entitlements-api-go/config"
 	. "github.com/RedHatInsights/entitlements-api-go/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,3 +14,7 @@ func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controllers Suite")
 }
+
+var _ = BeforeSuite(func() {
+	config.GetConfig().Options.Set(config.Keys.ITServicesTimeoutSeconds, 2)
+})


### PR DESCRIPTION
## Summary
* don't instantiate new http clients for every request to /services or /compliance

### Why
Right now, on every call to `/services` or `/compliance`, we instantiate a new a new `http.Client`. This goes against go's own instructions listed here: https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/net/http/client.go;l=33-35

> // The [Client.Transport] typically has internal state (cached TCP
// connections), so Clients should be reused instead of created as
// needed. Clients are safe for concurrent use by multiple goroutines.

We are frequently hitting our cpu limit in our pods and we think it's because we are using a different http client per request, which circumvents the thread safety provided by go 

### Ticket
https://issues.redhat.com/browse/RHCLOUD-31335
