### PR TITLE
fixed units for 'Error Rate in 3scale' panels

### DIFF
--- a/dashboards/grafana-dashboard-insights-entitlement-operations.yaml
+++ b/dashboards/grafana-dashboard-insights-entitlement-operations.yaml
@@ -73,7 +73,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": null,
+      "id": 688032,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -116,11 +116,11 @@ data:
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
                   },
                   {
-                    "color": "red",
+                    "color": "green",
                     "value": 99
                   }
                 ]
@@ -405,7 +405,7 @@ data:
                 "h": 6,
                 "w": 24,
                 "x": 0,
-                "y": 2
+                "y": 18
               },
               "id": 69,
               "options": {
@@ -456,7 +456,7 @@ data:
                 "h": 7,
                 "w": 7,
                 "x": 0,
-                "y": 8
+                "y": 24
               },
               "id": 71,
               "options": {
@@ -554,7 +554,7 @@ data:
                 "h": 7,
                 "w": 17,
                 "x": 7,
-                "y": 8
+                "y": 24
               },
               "id": 73,
               "options": {
@@ -775,7 +775,7 @@ data:
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 15
+                "y": 31
               },
               "id": 75,
               "options": {
@@ -878,7 +878,7 @@ data:
                 "h": 7,
                 "w": 7,
                 "x": 0,
-                "y": 24
+                "y": 40
               },
               "id": 77,
               "options": {
@@ -976,7 +976,7 @@ data:
                 "h": 7,
                 "w": 17,
                 "x": 7,
-                "y": 24
+                "y": 40
               },
               "id": 79,
               "options": {
@@ -1043,7 +1043,7 @@ data:
                 "h": 10,
                 "w": 24,
                 "x": 0,
-                "y": 31
+                "y": 47
               },
               "hiddenSeries": false,
               "id": 81,
@@ -1188,7 +1188,7 @@ data:
                 "h": 6,
                 "w": 24,
                 "x": 0,
-                "y": 41
+                "y": 57
               },
               "id": 83,
               "options": {
@@ -1288,7 +1288,7 @@ data:
                 "h": 6,
                 "w": 7,
                 "x": 0,
-                "y": 47
+                "y": 63
               },
               "id": 85,
               "options": {
@@ -1383,7 +1383,7 @@ data:
                 "h": 6,
                 "w": 17,
                 "x": 7,
-                "y": 47
+                "y": 63
               },
               "id": 87,
               "options": {
@@ -1477,7 +1477,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -1493,7 +1494,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 3
+                "y": 19
               },
               "id": 34,
               "links": [],
@@ -1560,7 +1561,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 3
+                "y": 19
               },
               "heatmap": {},
               "hideZeroBuckets": false,
@@ -1685,7 +1686,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -1701,7 +1703,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 11
+                "y": 27
               },
               "id": 35,
               "links": [],
@@ -1764,7 +1766,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 11
+                "y": 27
               },
               "heatmap": {},
               "hideZeroBuckets": false,
@@ -1888,7 +1890,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -1904,7 +1907,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 19
+                "y": 35
               },
               "id": 5,
               "links": [],
@@ -1982,7 +1985,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -1990,7 +1994,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "percent"
+                  "unit": "percentunit"
                 },
                 "overrides": []
               },
@@ -1998,7 +2002,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 19
+                "y": 35
               },
               "id": 13,
               "links": [],
@@ -2097,7 +2101,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2112,7 +2117,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 115
+                "y": 20
               },
               "id": 46,
               "options": {
@@ -2178,7 +2183,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 115
+                "y": 20
               },
               "heatmap": {},
               "hideZeroBuckets": false,
@@ -2305,7 +2310,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2321,7 +2327,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 123
+                "y": 28
               },
               "id": 53,
               "links": [],
@@ -2389,7 +2395,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 123
+                "y": 28
               },
               "heatmap": {},
               "hideZeroBuckets": false,
@@ -2516,7 +2522,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2532,7 +2539,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 131
+                "y": 36
               },
               "id": 55,
               "links": [],
@@ -2613,7 +2620,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2621,7 +2629,7 @@ data:
                       }
                     ]
                   },
-                  "unit": "percent"
+                  "unit": "percentunit"
                 },
                 "overrides": []
               },
@@ -2629,7 +2637,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 131
+                "y": 36
               },
               "id": 56,
               "links": [],
@@ -3619,7 +3627,11 @@ data:
             "type": "datasource"
           },
           {
-            "current": {},
+            "current": {
+              "selected": false,
+              "text": "entitlements-prod",
+              "value": "entitlements-prod"
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "$datasource"
@@ -3675,7 +3687,7 @@ data:
       "timezone": "",
       "title": "Operations - Entitlements",
       "uid": "TjP_nMWMkd",
-      "version": 3
+      "version": 4,
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
fix for units used in the 'Error Rate in 3scale' panels

![image](https://github.com/RedHatInsights/entitlements-api-go/assets/89980168/410fcb7d-40d6-47ff-a4a6-3228d6810737)

and
small format updates for 'Percentage of request status' row