### PR TITLE
Update pipeline to build source images by changing default value to true

### DIFF
--- a/.tekton/entitlements-api-go-pull-request.yaml
+++ b/.tekton/entitlements-api-go-pull-request.yaml
@@ -112,7 +112,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/entitlements-api-go-push.yaml
+++ b/.tekton/entitlements-api-go-push.yaml
@@ -109,7 +109,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
# Platform Security
Within the guide: 
"Per the Red Hat policy, you will need to update the pipeline to build source images. For doing that, you should change the build-source-image parameter in both pipelines default value to “true”.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
