### PR TITLE
[RHCLOUD-33893] Fix Entitlements pr-check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,6 +7,9 @@ export APP_NAME="entitlements"  # name of app-sre "application" folder this comp
 export COMPONENT_NAME="entitlements-api-go"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 export IMAGE="quay.io/cloudservices/entitlements-api-go"  # the image location on quay
 
+export GOROOT="/opt/go/1.20.10"
+export PATH="${GOROOT}/bin:${PATH}"
+
 echo "*** GO version ***"
 go version
 


### PR DESCRIPTION
[RHCLOUD-33893](https://issues.redhat.com/browse/RHCLOUD-33893)

the pr-check is [failing](https://ci.ext.devshift.net/job/RedHatInsights-entitlements-api-go-pr-check/315/) due to an inconsistency between Go version used in the entitlements project (1.20) and default Go version used by Jenkins worker (1.21)

so we need to set the Go version in our pr-check script

Jenkins worker available GO versions https://gitlab.cee.redhat.com/app-sre/infra/-/blob/master/packer/ansible/roles/jenkins-worker-golang/tasks/main.yml?ref_type=heads