### PR TITLE
[RHCLOUD-33915] change ioutil.Discard into io.Discard and ioutil.ReadFile into os.ReadFile

### DIFF
--- a/apispec/spec_provider.go
+++ b/apispec/spec_provider.go
@@ -1,9 +1,9 @@
 package apispec
 
 import (
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/RedHatInsights/entitlements-api-go/config"
 	"github.com/go-chi/chi/v5"
@@ -12,7 +12,7 @@ import (
 // OpenAPISpec responds back with the openapi spec
 func OpenAPISpec(r chi.Router) {
 	specFilePath := config.GetConfig().Options.GetString(config.Keys.OpenAPISpecPath)
-	specFile, err := ioutil.ReadFile(specFilePath)
+	specFile, err := os.ReadFile(specFilePath)
 	if err != nil {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("OpenApi Spec not available\n"))

--- a/logger/main.go
+++ b/logger/main.go
@@ -2,7 +2,7 @@ package logger
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -43,7 +43,7 @@ func InitLogger() *logrus.Logger {
 
 		// Disable app logs while running tests
 		if test {
-			Log.Out = ioutil.Discard
+			Log.Out = io.Discard
 		}
 
 		formatter := &logrus.JSONFormatter{


### PR DESCRIPTION
[RHCLOUD-33915](https://issues.redhat.com/browse/RHCLOUD-33915)

ioutil.Discard is deprecated: As of Go 1.16, this value is simply io.Discard. https://pkg.go.dev/io/ioutil#Discard

ioutil.ReadFile is deprecated: As of Go 1.16, this function simply calls os.ReadFile. https://pkg.go.dev/io/ioutil#ReadFile