### PR TITLE
Create IMAGE parameter in entitlements

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -23,7 +23,7 @@ objects:
           name: default-entitlements-config
         initContainers:
           - name: bundle-sync
-            image: quay.io/cloudservices/entitlements-api-go:${IMAGE_TAG}
+            image: ${IMAGE}:${IMAGE_TAG}
             command: ["/bundle-sync"]
             env:
               - name: ENT_SUBS_HOST
@@ -59,7 +59,7 @@ objects:
                 memory: ${MEMORY_REQUESTS}
         minReadySeconds: 15
         progressDeadlineSeconds: 600
-        image: quay.io/cloudservices/entitlements-api-go:${IMAGE_TAG}
+        image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -165,6 +165,9 @@ objects:
           name: default-entitlements-config
 
 parameters:
+- description: image
+  name: IMAGE
+  value: quay.io/cloudservices/platform-feedback
 - description: Log level for the application
   name: LOG_LEVEL
   required: false


### PR DESCRIPTION
Create image parameter within entitlements-api-go to try to see if this can help with the image issue for konflux pipelines. 

Right now, they are referring to cloudservices, and for the konflux tests to pass, they need to be passing to the new image:https://quay.io/repository/redhat-user-workloads/hcc-accessmanagement-tenant/entitlements-api-go/entitlements-api-go?tab=tags&tag=latest

the overriding should be done automatically through the konflux test, which is why I was thinking of updating this file directly  