### PR TITLE
[RHCLOUD-36134] upgrade aws-sdk-go and golang-jwt to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/glog v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/766b/chi-logger v0.0.0-20180309043024-d2679d398ce4
-	github.com/aws/aws-sdk-go v1.54.17
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/getkin/kin-openapi v0.118.0
 	github.com/getsentry/sentry-go v0.20.0
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.54.17 h1:ZV/qwcCIhMHgsJ6iXXPVYI0s1MdLT+5LW28ClzCUPeI=
-github.com/aws/aws-sdk-go v1.54.17/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
[RHCLOUD-36134](https://issues.redhat.com/browse/RHCLOUD-36134)

upgrade `github.com/aws/aws-sdk-go` package to the latest version => generate new image with latest base image and fix some vulnerabilities

and upgrade `github.com/golang-jwt/jwt/v4` to the latest version and fix vulnerability GHSA-29wx-vh33-7x7r

```
NAME                          INSTALLED          FIXED-IN            TYPE       VULNERABILITY        SEVERITY 
bzip2-libs                    1.0.6-26.el8       0:1.0.6-27.el8_10   rpm        CVE-2019-12900       Low       
github.com/golang-jwt/jwt/v4  v4.5.0             4.5.1               go-module  GHSA-29wx-vh33-7x7r  Low       
krb5-libs                     1.18.2-29.el8_10   0:1.18.2-30.el8_10  rpm        CVE-2024-3596        High      
openssl-libs                  1:1.1.1k-12.el8_9  1:1.1.1k-14.el8_6   rpm        CVE-2024-5535        Low       
stdlib                        go1.20.10          1.21.11, 1.22.4     go-module  CVE-2024-24790       Critical  
stdlib                        go1.20.10          1.21.0-0            go-module  CVE-2023-24531       Critical  
stdlib                        go1.20.10          1.22.7, 1.23.1      go-module  CVE-2024-34158       High      
stdlib                        go1.20.10          1.22.7, 1.23.1      go-module  CVE-2024-34156       High      
stdlib                        go1.20.10          1.21.12, 1.22.5     go-module  CVE-2024-24791       High      
stdlib                        go1.20.10          1.21.8, 1.22.1      go-module  CVE-2024-24784       High      
stdlib                        go1.20.10          1.21.9, 1.22.2      go-module  CVE-2023-45288       High      
stdlib                        go1.20.10          1.20.12, 1.21.5     go-module  CVE-2023-45285       High      
stdlib                        go1.20.10          1.22.7, 1.23.1      go-module  CVE-2024-34155       Medium    
stdlib                        go1.20.10          1.21.11, 1.22.4     go-module  CVE-2024-24789       Medium    
stdlib                        go1.20.10          1.21.10, 1.22.3     go-module  CVE-2024-24787       Medium    
stdlib                        go1.20.10          1.21.8, 1.22.1      go-module  CVE-2024-24783       Medium    
stdlib                        go1.20.10          1.21.8, 1.22.1      go-module  CVE-2023-45289       Medium    
stdlib                        go1.20.10          1.20.12, 1.21.5     go-module  CVE-2023-39326       Medium    
stdlib                        go1.20.10          1.21.8, 1.22.1      go-module  CVE-2024-24785       Unknown   
stdlib                        go1.20.10          1.21.8, 1.22.1      go-module  CVE-2023-45290       Unknown
```