### PR TITLE
[RHCLOUD-37580] specify the base image version in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN make
 
 # Using ubi8-minimal due to its smaller footprint
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 WORKDIR /
 


### PR DESCRIPTION
[RHCLOUD-37580](https://issues.redhat.com/browse/RHCLOUD-37580)

base image ubi8/ubi-minimal in the RH catalog: https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?container-tabs=overview

this change will enable the Konflux Bot to automatically detect when a new base image version is released and create a PR for the update and we will have better control over the base image version