### PR TITLE
update Feature to parse isEntitled in json

### DIFF
--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -270,7 +270,7 @@ func Services() func(http.ResponseWriter, *http.Request) {
 				entitle = false
 				for _, f := range subscriptions.Data.Features {
 					if f.Name == b.Name {
-						entitle = f.Entitled
+						entitle = f.IsEntitled
 						trial = f.IsEval
 					}
 				}

--- a/controllers/subscriptions.go
+++ b/controllers/subscriptions.go
@@ -257,37 +257,37 @@ func Services() func(http.ResponseWriter, *http.Request) {
 				}
 			}
 
-			entitle := true
-			trial := false
+			isEntitled := true
+			isTrial := false
 			entitleAll := configOptions.GetString(config.Keys.EntitleAll)
 
 			if entitleAll == "true" {
-				entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
+				entitlementsResponse[b.Name] = setBundlePayload(isEntitled, isTrial)
 				continue
 			}
 
 			if len(b.Skus) > 0 {
-				entitle = false
+				isEntitled = false
 				for _, f := range subscriptions.Data.Features {
 					if f.Name == b.Name {
-						entitle = f.IsEntitled
-						trial = f.IsEval
+						isEntitled = f.IsEntitled
+						isTrial = f.IsEval
 					}
 				}
 			}
 
 			if b.UseValidAccNum {
-				entitle = validAccNum && entitle
+				isEntitled = validAccNum && isEntitled
 			}
 
 			if b.UseValidOrgId {
-				entitle = validOrgId && entitle
+				isEntitled = validOrgId && isEntitled
 			}
 
 			if b.UseIsInternal {
-				entitle = validAccNum && isInternal && validEmailMatch
+				isEntitled = validAccNum && isInternal && validEmailMatch
 			}
-			entitlementsResponse[b.Name] = setBundlePayload(entitle, trial)
+			entitlementsResponse[b.Name] = setBundlePayload(isEntitled, isTrial)
 		}
 
 		obj, err := json.Marshal(entitlementsResponse)

--- a/controllers/subscriptions_test.go
+++ b/controllers/subscriptions_test.go
@@ -284,12 +284,12 @@ var _ = Describe("Services Controller", func() {
 						{
 							Name:     "TestBundle1",
 							IsEval:   false,
-							Entitled: false,
+							IsEntitled: false,
 						},
 						{
 							Name:     "TestBundle2",
 							IsEval:   true,
-							Entitled: true,
+							IsEntitled: true,
 						},
 					},
 				},

--- a/types/main.go
+++ b/types/main.go
@@ -20,7 +20,7 @@ type SubscriptionsResponse struct {
 type Feature struct {
 	Name     string `json:"name"`
 	IsEval   bool   `json:"isEval"`
-	Entitled bool   `json:"entitled"`
+	IsEntitled bool   `json:"isEntitled"`
 }
 
 type FeatureStatus struct {


### PR DESCRIPTION
## Summary
parse `isEntitled` in response from feature service

### Why
When migrating to feature service, they changed the response in the endpoint we use

subs returns:
```
    {
      "name": "smart_management",
      "isEval": false,
      "entitled": true
    },
```

feature returns:
```
    {
      "name": "smart_management",
      "isEval": false,
      "isEntitled": true
    },
```
so they switched from `entitled` to `isEntitled`

this broke the logic in the `/services` endpoint because we are still parsing for `entitled` which results in all sku based features returned `is_entitled: false` when they should be true

### Ticket
https://issues.redhat.com/browse/RHCLOUD-39569

### Testing
1. setup local env:
```
export ENT_CERTS_FROM_ENV=false
export ENT_KEY=./local/stage.key # copy from vault
export ENT_CERT=./local/stage.crt # copy from vault
export ENT_CA_PATH=./resources/ca.crt
export ENT_SUBS_HOST=https://feature.stage.api.redhat.com
export ENT_DEBUG=true
export ENT_LOG_LEVEL=Debug
export ENT_FEATURES='ansible,smart_management,rhods,rhoam,rhosak,openshift,acs'
export ENT_RUN_BUNDLE_SYNC=true
```

2. copy stage bundle [here](https://github.com/RedHatInsights/entitlements-config/blob/master/configs/stage/bundles.yml) locally to `bundles/bundles.yml` - note you only need to copy the data, not the openshift template bits
3. build and run the service:
```
make build

make exe
```
4. I generated an identity header for one of the affected accounts (listed in the ticket) by running `scripts/xrhid.sh` after updating the `org_id` in there to `18939256` - the result is in the request below you can use
5. make request to entitlements:
```
curl --location 'http://localhost:3000/api/entitlements/v1/services' \
--header 'x-rh-identity: eyAiaWRlbnRpdHkiIDogeyAiYWNjb3VudF9udW1iZXIiOiAiNTQwMTU1IiwgInR5cGUiOiAiVXNlciIsICJpbnRlcm5hbCI6IHsgIm9yZ19pZCI6ICIxODkzOTI1NiIgfSwgInVzZXIiOiB7ICJpc19vcmdfYWRtaW4iOiB0cnVlIH0gfSB9Cg=='
```
6. result should include:
```
    "smart_management": {
        "is_entitled": true,
        "is_trial": true
    },
```
which is correct

if you repeat these tests but build from `main`, you will see the current bugged result:
```
    "smart_management": {
        "is_entitled": false,
        "is_trial": true
    },
```

## Summary by Sourcery

Update feature parsing to support the new `isEntitled` field from the feature service instead of the previous `entitled` field

Bug Fixes:
- Fix entitlement parsing for SKU-based features by updating the code to use the new `isEntitled` field instead of the deprecated `entitled` field

Enhancements:
- Modify type definitions and parsing logic to accommodate changes in the feature service response structure