### PR TITLE
run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/redhatinsights/platform-go-middlewares v1.0.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0
-	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
 	golang.org/x/text v0.22.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -72,6 +71,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect


### PR DESCRIPTION
run go mod tidy because konflux pipeline is failing due to:
```
go: updates to go.mod needed; to update it:
	go mod tidy
make: *** [Makefile:16: api/server.gen.go] Error 1
```
https://console.redhat.com/application-pipeline/workspaces/hcc-accessmanagement/applications/entitlements-api-go/pipelineruns/entitlements-api-go-on-pull-request-f98jp

## Summary by Sourcery

Chores:
- Run go mod tidy to resolve module dependency inconsistencies and update go.mod file