### PR TITLE
bump base image ubi9/go-goolset to the latest version

### DIFF
--- a/.tekton/entitlements-api-go-pull-request.yaml
+++ b/.tekton/entitlements-api-go-pull-request.yaml
@@ -218,7 +218,7 @@ spec:
           # set the working directory to value from previous step
           workingDir: /var/workdir/source
           # Use image that suites your use case
-          image: registry.access.redhat.com/ubi9/go-toolset:9.5-1743094161
+          image: registry.access.redhat.com/ubi9/go-toolset:9.5-1745328278
           securityContext:
           # If the task step needs write access to the volume, set the runAsUser to 0 (root).
             runAsUser: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Use go-toolset as the builder image
 # Once built, copys GO executable to a smaller image and runs it from there
 
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1743582279 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1745328278 as builder
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump the UBI9 Go toolset image from version 9.5-1743094161 and 9.5-1743582279 to 9.5-1745328278 in Tekton pipeline and Dockerfile