### PR TITLE
upgrade golang into version 1.23.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make
 
 If your local version differs from what entitlements is using, you can download the desired version of go here: [go.dev/doc/manage-install](https://go.dev/doc/manage-install), and then pass the path to the go binary to all make commands like so:
 ```sh
-make GO=~/go/bin/go1.22
+make GO=~/go/bin/go1.23
 ```
 
 ## Certificates and Configuration

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/entitlements-api-go
 
-go 1.22.9
+go 1.23.6
 
 require (
 	github.com/766b/chi-logger v0.0.0-20180309043024-d2679d398ce4

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,8 +7,7 @@ export APP_NAME="entitlements"  # name of app-sre "application" folder this comp
 export COMPONENT_NAME="entitlements-api-go"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 export IMAGE="quay.io/cloudservices/entitlements-api-go"  # the image location on quay
 
-export GOROOT="/opt/go/1.22.5"
-export PATH="${GOROOT}/bin:${PATH}"
+export GOTOOLCHAIN="auto"
 
 echo "*** GO version ***"
 go version


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Golang version from 1.22 to 1.23.6 across project configuration files

Enhancements:
- Update project's Go version to the latest release, including modifications to go.mod, README.md, and CI scripts

Chores:
- Update GOROOT configuration and PATH settings in CI scripts