### PR TITLE
update the action to be possible to share repository secrets

### DIFF
--- a/.github/workflows/quay-image-check.yml
+++ b/.github/workflows/quay-image-check.yml
@@ -1,11 +1,9 @@
 name: Check Quay Image
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+    push:
+      branches:
+        - main
 
 jobs:
   check-image:


### PR DESCRIPTION
the `on pull_request` action type doesn't allow to access the repository secrets (in case the pull request was created from the fork) so I changed the action type to by `on push`