### PR TITLE
upgrade golang to the 1.23.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/entitlements-api-go
 
-go 1.23.6
+go 1.23.9
 
 require (
 	github.com/766b/chi-logger v0.0.0-20180309043024-d2679d398ce4


### PR DESCRIPTION
new base image supports golang 1.23.9 and that will fix some vulnerabilities too