### PR TITLE
RHCLOUD-40635 | feature: enable automatic certificate renewal for Entitlements

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -25,82 +25,88 @@ type EntitlementsConfig struct {
 
 // EntitlementsConfigKeysType is the definition of the struct hat houses all the env variables key names
 type EntitlementsConfigKeysType struct {
-	Key                      string
-	Cert                     string
-	Port                     string
-	LogLevel                 string
-	CertsFromEnv             string
-	SubsHost                 string
-	ComplianceHost           string
-	CaPath                   string
-	OpenAPISpecPath          string
-	BundleInfoYaml           string
-	CwLogGroup               string
-	CwLogStream              string
-	CwRegion                 string
-	CwKey                    string
-	CwSecret                 string
-	Features                 string
-	SubAPIBasePath           string
-	CompAPIBasePath          string
-	RunBundleSync            string
-	EntitleAll               string
-	AMSHost                  string
-	ClientID                 string
-	ClientSecret             string
-	TokenURL                 string
-	Debug                    string
-	BOPClientID              string
-	BOPToken                 string
-	BOPURL                   string
-	BOPEnv                   string
-	BOPMockOrgId             string
-	DisableSeatManager       string
-	SubsCacheDuration        string
-	SubsCacheMaxSize         string
-	SubsCacheItemPrune       string
-	AMSAcctMgmt11Msg         string
-	ITServicesTimeoutSeconds string
+	AutomaticCertificateRenewalEnabled string
+	Key                                string
+	Cert                               string
+	Port                               string
+	LogLevel                           string
+	CertsFromEnv                       string
+	SubsHost                           string
+	ComplianceHost                     string
+	CaPath                             string
+	OpenAPISpecPath                    string
+	BundleInfoYaml                     string
+	CwLogGroup                         string
+	CwLogStream                        string
+	CwRegion                           string
+	CwKey                              string
+	CwSecret                           string
+	Features                           string
+	SubAPIBasePath                     string
+	CompAPIBasePath                    string
+	RunBundleSync                      string
+	EntitleAll                         string
+	AMSHost                            string
+	ClientID                           string
+	ClientSecret                       string
+	TokenURL                           string
+	Debug                              string
+	BOPClientID                        string
+	BOPToken                           string
+	BOPURL                             string
+	BOPEnv                             string
+	BOPMockOrgId                       string
+	DisableSeatManager                 string
+	SubsCacheDuration                  string
+	SubsCacheMaxSize                   string
+	SubsCacheItemPrune                 string
+	AMSAcctMgmt11Msg                   string
+	ITCertificate                      string
+	ITKey                              string
+	ITServicesTimeoutSeconds           string
 }
 
 // Keys is a struct that houses all the env variables key names
 var Keys = EntitlementsConfigKeysType{
-	Key:                      "KEY",
-	Cert:                     "CERT",
-	Port:                     "PORT",
-	LogLevel:                 "LOG_LEVEL",
-	CertsFromEnv:             "CERTS_FROM_ENV",
-	SubsHost:                 "SUBS_HOST",
-	ComplianceHost:           "COMPLIANCE_HOST",
-	CaPath:                   "CA_PATH",
-	OpenAPISpecPath:          "OPENAPI_SPEC_PATH",
-	BundleInfoYaml:           "BUNDLE_INFO_YAML",
-	CwLogGroup:               "CW_LOG_GROUP",
-	CwLogStream:              "CW_LOG_STEAM",
-	CwRegion:                 "CW_REGION",
-	CwKey:                    "CW_KEY",
-	CwSecret:                 "CW_SECRET",
-	Features:                 "FEATURES",
-	SubAPIBasePath:           "SUB_API_BASE_PATH",
-	CompAPIBasePath:          "COMP_API_BASE_PATH",
-	RunBundleSync:            "RUN_BUNDLE_SYNC",
-	EntitleAll:               "ENTITLE_ALL",
-	AMSHost:                  "AMS_HOST",
-	ClientID:                 "OIDC_CLIENT_ID",
-	ClientSecret:             "OIDC_CLIENT_SECRET",
-	TokenURL:                 "OAUTH_TOKEN_URL",
-	BOPClientID:              "BOP_CLIENT_ID",
-	BOPToken:                 "BOP_TOKEN",
-	BOPURL:                   "BOP_URL",
-	BOPMockOrgId:             "BOP_MOCK_ORG_ID",
-	BOPEnv:                   "BOP_ENV",
-	Debug:                    "DEBUG",
-	DisableSeatManager:       "DISABLE_SEAT_MANAGER",
-	SubsCacheDuration:        "SUBS_CACHE_DURATION_SECONDS",
-	SubsCacheMaxSize:         "SUBS_CACHE_MAX_SIZE",
-	SubsCacheItemPrune:       "SUBS_CACHE_ITEM_PRUNE",
-	AMSAcctMgmt11Msg:         "AMS_ACCT_MGMT_11_ERR_MSG",
-	ITServicesTimeoutSeconds: "IT_SERVICES_TIMEOUT_SECONDS",
+	AutomaticCertificateRenewalEnabled: "AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED",
+	Key:                                "KEY",
+	Cert:                               "CERT",
+	Port:                               "PORT",
+	LogLevel:                           "LOG_LEVEL",
+	CertsFromEnv:                       "CERTS_FROM_ENV",
+	SubsHost:                           "SUBS_HOST",
+	ComplianceHost:                     "COMPLIANCE_HOST",
+	CaPath:                             "CA_PATH",
+	OpenAPISpecPath:                    "OPENAPI_SPEC_PATH",
+	BundleInfoYaml:                     "BUNDLE_INFO_YAML",
+	CwLogGroup:                         "CW_LOG_GROUP",
+	CwLogStream:                        "CW_LOG_STEAM",
+	CwRegion:                           "CW_REGION",
+	CwKey:                              "CW_KEY",
+	CwSecret:                           "CW_SECRET",
+	Features:                           "FEATURES",
+	SubAPIBasePath:                     "SUB_API_BASE_PATH",
+	CompAPIBasePath:                    "COMP_API_BASE_PATH",
+	RunBundleSync:                      "RUN_BUNDLE_SYNC",
+	EntitleAll:                         "ENTITLE_ALL",
+	AMSHost:                            "AMS_HOST",
+	ClientID:                           "OIDC_CLIENT_ID",
+	ClientSecret:                       "OIDC_CLIENT_SECRET",
+	TokenURL:                           "OAUTH_TOKEN_URL",
+	BOPClientID:                        "BOP_CLIENT_ID",
+	BOPToken:                           "BOP_TOKEN",
+	BOPURL:                             "BOP_URL",
+	BOPMockOrgId:                       "BOP_MOCK_ORG_ID",
+	BOPEnv:                             "BOP_ENV",
+	Debug:                              "DEBUG",
+	DisableSeatManager:                 "DISABLE_SEAT_MANAGER",
+	SubsCacheDuration:                  "SUBS_CACHE_DURATION_SECONDS",
+	SubsCacheMaxSize:                   "SUBS_CACHE_MAX_SIZE",
+	SubsCacheItemPrune:                 "SUBS_CACHE_ITEM_PRUNE",
+	AMSAcctMgmt11Msg:                   "AMS_ACCT_MGMT_11_ERR_MSG",
+	ITCertificate:                      "IT_CERTIFICATE",
+	ITKey:                              "IT_KEY",
+	ITServicesTimeoutSeconds:           "IT_SERVICES_TIMEOUT_SECONDS",
 }
 
 func getRootCAs(localCertFile string) *x509.CertPool {
@@ -131,6 +137,13 @@ func loadCerts(options *viper.Viper) (tls.Certificate, error) {
 		return tls.X509KeyPair(
 			[]byte(options.GetString(Keys.Cert)),
 			[]byte(options.GetString(Keys.Key)),
+		)
+	}
+
+	if options.GetBool(Keys.AutomaticCertificateRenewalEnabled) {
+		return tls.LoadX509KeyPair(
+			options.GetString(Keys.ITCertificate),
+			options.GetString(Keys.ITKey),
 		)
 	}
 

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -34,6 +34,8 @@ objects:
                 value: 'true'
               - name: ENT_RUN_BUNDLE_SYNC
                 value: ${RUN_BUNDLE_SYNC}
+              - name: ENT_AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED
+                value: ${AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED}
               - name: ENT_CERT
                 valueFrom:
                   secretKeyRef:
@@ -46,13 +48,25 @@ objects:
                     name: go-api-certs
                     key: ENT_KEY
                     optional: true
+              - name: ENT_IT_CERTIFICATE
+                valueFrom:
+                  secretKeyRef:
+                    name: it-key-pair
+                    key: tls.crt
+                    optional: true
+              - name: ENT_IT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: it-key-pair
+                    key: tls.key
+                    optional: true
             volumeMounts:
             - mountPath: /bundles
               name: default-entitlements-config
             inheritEnv: true
             resources:
               limits:
-                cpu: ${CPU_LIMIT} 
+                cpu: ${CPU_LIMIT}
                 memory: ${MEMORY_LIMIT}
               requests:
                 cpu: ${CPU_REQUESTS}
@@ -75,7 +89,7 @@ objects:
           timeoutSeconds: 60
         resources:
           limits:
-            cpu: ${CPU_LIMIT} 
+            cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
             cpu: ${CPU_REQUESTS}
@@ -122,6 +136,8 @@ objects:
             value: ${AMS_ACCT_MGMT_11_ERR_MSG}
           - name: ENT_IT_SERVICES_TIMEOUT_SECONDS
             value: ${IT_SERVICES_TIMEOUT_SECONDS}
+          - name: ENT_AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED
+            value: ${AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED}
           - name: GLITCHTIP_DSN
             valueFrom:
               secretKeyRef:
@@ -139,6 +155,18 @@ objects:
               secretKeyRef:
                 name: go-api-certs
                 key: ENT_KEY
+          - name: ENT_IT_CERTIFICATE
+            valueFrom:
+              secretKeyRef:
+                name: it-key-pair
+                key: tls.crt
+                optional: true
+          - name: ENT_IT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: it-key-pair
+                key: tls.key
+                optional: true
           - name: ENT_OIDC_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -245,3 +273,6 @@ parameters:
 - description: Timeout for outbound requests to IT services, in seconds
   name: IT_SERVICES_TIMEOUT_SECONDS
   required: false
+- description: Enables grabbing the certificates from the secret that provides certificates that will be automatically renewed.
+  name: AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED
+  value: 'false'


### PR DESCRIPTION
In order to be able to make use of the automatic certificate renewals, we need to adjust some environment variables that Entitlements can take. And so as to avoid having downtimes in case we face any issues with it, the change comes behind a flag which can be enabled or disabled.

## Jira ticket
[[RHCLOUD-40635]](https://issues.redhat.com/browse/RHCLOUD-40635)