### PR TITLE
paramaterize certs_from_env

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -273,7 +273,7 @@ parameters:
 - description: Timeout for outbound requests to IT services, in seconds
   name: IT_SERVICES_TIMEOUT_SECONDS
   required: false
-- description: Booleon to determine if we should retrieve certs from env vars or not
+- description: Boolean to determine if we should retrieve certs from env vars or not
   name: CERTS_FROM_ENV
   required: true
   value: 'true'


### PR DESCRIPTION
update template to provide ENT_CERTS_FROM_ENV as a parameter in deployments

related to this PR: https://github.com/RedHatInsights/entitlements-api-go/pull/366
if we enable `AUTOMATIC_CERTIFICATE_RENEWAL_ENABLED` we need to disable `CERTS_FROM_ENV`, otherwise we could fail to start the app since we check for env certs first, and if they are absent we throw an error. See here: https://github.com/RedHatInsights/entitlements-api-go/blob/main/config/main.go#L136

related ticket: https://issues.redhat.com/browse/RHCLOUD-40635