### PR TITLE
Fail closed for SKU-based entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ docker run -p 3000:3000 entitlements-api-go
 The Entitlements API requires that you pass in a valid `x-redhat-identity` header or it rejects requests.
 For an example see `cat ./scripts/xrhid.sh`
 
+### Degraded state headers
+
+When the IT Feature Service is unavailable or returns a non-200 during `/api/entitlements/v1/services` calls, the API responds with HTTP 200 but defaults all SKU-based bundles to `is_entitled: false`. The response will include headers to signal a degraded state:
+
+- `X-Entitlements-Degraded`: `true` when a dependency failure occurred
+- `X-Entitlements-Degraded-Status`: HTTP status code from the dependency ("0" if none was received)
+
+Example:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Entitlements-Degraded: true
+X-Entitlements-Degraded-Status: 503
+
+{
+  "rhel": { "is_entitled": false, "is_trial": false },
+  "openshift": { "is_entitled": false, "is_trial": false },
+  "cloud": { "is_entitled": true,  "is_trial": false }
+}
+```
+
 ## Testing the bundle-sync
 
 To test the bundle sync behavior, you'll need to configure your environment similar to the instructions above, build the script, and run it against the dev environment:


### PR DESCRIPTION
When we receive a connection error, or non-200 response from the IT Feature Service, we may want to fail closed on SKU-based entitlements in order to still serve traffic on the platform, vs raising 500s and killing all non-cached requests coming in via the API.

This sets a degraded state for a request in those cases, removes the explicit exception, still tracks the failure metric, and sets degraded headers to inform clients.

**Things to still consider:**
- Is this behavior acceptable?
- What updates can/should we make in the gateway `x-rh-identity` construction to inform consumers of the identity-provided entitlements this is degraded data?
- Should the UI consume/key off these headers to inform users?

**TODO:**
- Right now this will cause requests to pile up because of our timeout to the IT service, and the fact that we don't currently cache failures.
- We should a) cache the empty response when we get a failure, and/or b) dynamically tweak the timeout based on degraded state (would require shared state), or c) ???

_Assisted by: gpt-5 (via Cursor IDE)_
