### PR TITLE
upgrade 'github.com/openshift-online/ocm-api-model' to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
-	github.com/openshift-online/ocm-api-model/clientapi v0.0.428 // indirect
-	github.com/openshift-online/ocm-api-model/model v0.0.428 // indirect
+	github.com/openshift-online/ocm-api-model/clientapi v0.0.429 // indirect
+	github.com/openshift-online/ocm-api-model/model v0.0.429 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,10 +146,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
-github.com/openshift-online/ocm-api-model/clientapi v0.0.428 h1:YnWZuehVqjvx6hL72fIR+cbjOE8KTxCLev1RqUY69rI=
-github.com/openshift-online/ocm-api-model/clientapi v0.0.428/go.mod h1:fZwy5HY2URG9nrExvQeXrDU/08TGqZ16f8oymVEN5lo=
-github.com/openshift-online/ocm-api-model/model v0.0.428 h1:3ErD9rAYafSQlaM/bzo9TnNyWLjSDEFJ0lzWh42F5h8=
-github.com/openshift-online/ocm-api-model/model v0.0.428/go.mod h1:PQIoq6P8Vlb7goOdRMLK8nJY+B7HH0RTqYAa4kyidTE=
+github.com/openshift-online/ocm-api-model/clientapi v0.0.429 h1:UyE7TKtyVtf9RlHVEghMr6ZXblO6cseCPdrB2UTfbc8=
+github.com/openshift-online/ocm-api-model/clientapi v0.0.429/go.mod h1:fZwy5HY2URG9nrExvQeXrDU/08TGqZ16f8oymVEN5lo=
+github.com/openshift-online/ocm-api-model/model v0.0.429 h1:FkgAaSAy+JExyJG0WmoyA9dMpPdgFFbk3J8AaUN41Vg=
+github.com/openshift-online/ocm-api-model/model v0.0.429/go.mod h1:PQIoq6P8Vlb7goOdRMLK8nJY+B7HH0RTqYAa4kyidTE=
 github.com/openshift-online/ocm-sdk-go v0.1.473 h1:m/NWIBCzhC/8PototMQ7x8MQXCeSLjW7q0qR7bPGXKk=
 github.com/openshift-online/ocm-sdk-go v0.1.473/go.mod h1:5Gw/YZE+c5FAPaBtO1w/asd9qbs2ljQwg7fpVq51UW4=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
changes from:

- [PR#443 ](https://github.com/RedHatInsights/entitlements-api-go/pull/443)chore(deps): update module github.com/openshift-online/ocm-api-model/model to v0.0.429 (red-hat-konflux[bot]) from August 17, 2025
- [PR#442 ](https://github.com/RedHatInsights/entitlements-api-go/pull/442)chore(deps): update module github.com/openshift-online/ocm-api-model/clientapi to v0.0.429 (red-hat-konflux[bot]) from August 17, 2025