### PR TITLE
[RHCLOUD-41491] Remove the Deprecated Bundles

### DIFF
--- a/bundle_sync/main.go
+++ b/bundle_sync/main.go
@@ -120,6 +120,7 @@ func main() {
 
 	endpoints := strings.Split(c.Options.GetString(config.Keys.Features), ",")
 	for _, endpoint := range endpoints {
+		log.Printf("Checking for updates to %s\n", endpoint)
 		skus := make(map[string][]string)
 		current_skus := make(map[string][]string)
 		url := fmt.Sprintf("%s%s",

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -218,7 +218,7 @@ parameters:
   value: 'entitlements-secret'
 - description: List of feature bundles to onboard during bundle sync
   name: FEATURES
-  value: ansible,smart_management,rhods,rhoam,rhosak,openshift,acs
+  value: ansible,rhods,openshift,acs
   required: false
 - description: Flag to disable seat manager by not exposing any of the apis related to the feature
   name: DISABLE_SEAT_MANAGER


### PR DESCRIPTION


Related JIRA link: https://issues.redhat.com/browse/RHCLOUD-41491

Based on JIRA ticket description:

Remove rhoam/rhosak/smart_management from entitlements bundles


Also added one line of logs to keep track of the endpoint, as suggested here in this slack thread: 
https://redhat-internal.slack.com/archives/C022YV4E0NA/p1756388374088139?thread_ts=1756330891.787499&cid=C022YV4E0NA

# Platform Security

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist 

## Secure Coding Checklist
- [ ] Input Validation

- [ ] Output Encoding

- [ ] Authentication and Password Management

- [ ] Session Management

- [ ] Access Control

- [ ] Cryptographic Practices

- [ ] Error Handling and Logging

- [ ] Data Protection

- [ ] Communication Security

- [ ] System Configuration

- [ ] Database Security

- [ ] File Management

- [ ] Memory Management

- [ ] General Coding Practices
