### PR TITLE
Revert "[RHCLOUD-41491] Remove the Deprecated Bundles"

### DIFF
--- a/bundle_sync/main.go
+++ b/bundle_sync/main.go
@@ -120,7 +120,6 @@ func main() {
 
 	endpoints := strings.Split(c.Options.GetString(config.Keys.Features), ",")
 	for _, endpoint := range endpoints {
-		log.Printf("Checking for updates to %s\n", endpoint)
 		skus := make(map[string][]string)
 		current_skus := make(map[string][]string)
 		url := fmt.Sprintf("%s%s",

--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -218,7 +218,7 @@ parameters:
   value: 'entitlements-secret'
 - description: List of feature bundles to onboard during bundle sync
   name: FEATURES
-  value: ansible,rhods,openshift,acs
+  value: ansible,smart_management,rhods,rhoam,rhosak,openshift,acs
   required: false
 - description: Flag to disable seat manager by not exposing any of the apis related to the feature
   name: DISABLE_SEAT_MANAGER


### PR DESCRIPTION
Reverts RedHatInsights/entitlements-api-go#465