### PR TITLE
log response from feature service in bundle sync

### DIFF
--- a/bundle_sync/main.go
+++ b/bundle_sync/main.go
@@ -63,6 +63,8 @@ func getCurrent(client *http.Client, url string) (t.SubModel, error) {
 	if err != nil {
 		return t.SubModel{}, err
 	}
+	
+	log.Printf("raw response from '%s': '%s'", url, string(data))
 
 	var currentSubs t.SubModel
 	err = json.Unmarshal(data, &currentSubs)


### PR DESCRIPTION
add a log in bundle sync that prints the raw response from feature service in our logs 

this will help when troubleshooting bundle sync failures in stage/prod