### PR TITLE
update bundle sync to support multiple rules on a feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ make build
 ./bundle-sync
 ```
 
+You can dry run bundle sync by using the '--dry-run' flag:
+```bash
+./bundle-sync --dry-run
+```
+This will run the program but won't actually POST any updates, it will just print them.
+
 ## Running the Unit Tests
 
 * To run the unit tests, execute the following commands from the terminal:
@@ -187,7 +193,5 @@ those files.
 **IMPORTANT**: if using automatic cert renewal, `ENT_CERTS_FROM_ENV` must be
 set to `false`.
 
-#### Manually via env or files
-If `ENT_CERTS_FROM_ENV` is set to `false`: store cert & key data in files, and set `ENT_CERT` and `ENT_KEY` to the locations of those files for the application to load.
-
+#### Manually via env (useful for local dev)
 If `ENT_CERTS_FROM_ENV` is set to `true`: store cert & key data in the env vars `ENT_CERT` and `ENT_KEY` directly.

--- a/types/main.go
+++ b/types/main.go
@@ -66,7 +66,7 @@ type RequestErrorResponse struct {
 // SubModel is the struct for GET and POST data for subscriptions
 type SubModel struct {
 	Name  string `json:"name"`
-	Rules Rules  `json:"rules"`
+	Rules []Rules  `json:"rules"`
 }
 
 // Rules contains match and exclude product arrays


### PR DESCRIPTION
## Summary
* Update the bundle sync program to support multiple rules on a Feature
* Added dry run option to bundle sync for local testing

### Tickets
https://issues.redhat.com/browse/RHCLOUD-42320

### Why
Recently the feature service updated the schema of their Feature object. See this ticket: https://issues.redhat.com/browse/ITPRODSUB-26524
They now support multiple rules on a Feature, which means there is now an array where an object used to be. So we have to update our serialization of the Feature objects to support arrays where previously we did not. 

Right now bundle sync is broken due to de-serialization errors:
```
2025/09/23 21:12:27 Unable to get current features: json: cannot unmarshal array into Go struct field SubModel.rules of type types.Rules
```

### Testing
1. build the branch locally
2. copy the stage bundles to local `bundles/bundles.yml` from [entitlements-config](https://github.com/RedHatInsights/entitlements-config/blob/master/configs/stage/bundles.yml)
3. run bundle sync like so 
```
./bundle-sync --dry-run
```
4. verify no errors and you should see some output indicating the updates that would be made
5. the updates should contain valid json with `$.rules` being an array with one value, example:
```
2025/09/23 16:15:41 *** POST 'https://feature.stage.api.redhat.com/features/v1/' - '{"name":"rhosak","rules":[{"matchProducts":[{"skuCodes":["MW01882","MW01891","MW01891","MW01892MO","MW01892MO","MW01893","MW01894","MW01895MO","MW01896MO"]}]}]}'
```