### PR TITLE
chore: update UBI9 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Use go-toolset as the builder image
 # Once built, copys GO executable to a smaller image and runs it from there
 
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1780490420 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1781070142 as builder
 
 WORKDIR /go/src/app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/entitlements-api-go
 
-go 1.26.3
+go 1.26.2
 
 require (
 	github.com/766b/chi-logger v0.0.0-20180309043024-d2679d398ce4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/entitlements-api-go
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/766b/chi-logger v0.0.0-20180309043024-d2679d398ce4


### PR DESCRIPTION
## Summary

Update UBI9 container base images to latest available versions from Red Hat Container Catalog.

## Changes

| Dockerfile | Image | Old Tag | New Tag | Health |
|------------|-------|---------|---------|--------|
| `Dockerfile` | `ubi9/go-toolset` | `9.8-1780490420` | `9.8-1781070142` | A |

## Motivation

- Keep base images current with security patches
- Maintain compliance with container health requirements
- Reduce technical debt from outdated base images

## Verification

- [ ] Container builds succeed locally
- [ ] CI/CD pipeline passes
- [ ] Application functions correctly with updated base

## References

- [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/)
- Latest tags verified via Pyxis API

## Test Plan

1. Verify container builds complete successfully
2. Run application smoke tests
3. Confirm no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)
