### PR TITLE
chore(deps): consolidate 1 python dependency updates

### DIFF
--- a/.github/workflows/json-yaml-validation.yml
+++ b/.github/workflows/json-yaml-validation.yml
@@ -14,7 +14,7 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: json-yaml-validate
         id: json-yaml-validate


### PR DESCRIPTION
## Summary

Consolidates 1 python dependency update PRs from `red-hat-konflux[bot]` into a single PR for easier review.

## Consolidated PRs

- #966: chore(deps): update actions/checkout action to v7

## Why consolidate?

- Reduces CI/CD load from multiple small PRs
- Easier to review related dependency updates together
- Single merge commit instead of many

## Testing

- [ ] CI passes
- [ ] No breaking changes from dependency updates
